### PR TITLE
Don't render screen when overlay is visible

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -366,9 +366,12 @@ void Application::run()
       RA_DoAchievementsFrame();
     }
 
-    Gl::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    _video.draw();
-    SDL_GL_SwapWindow(_window);
+	if (!RA_IsOverlayFullyVisible())
+	{
+		Gl::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+		_video.draw();
+		SDL_GL_SwapWindow(_window);
+	}
 
     RA_HandleHTTPResults();
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -366,12 +366,12 @@ void Application::run()
       RA_DoAchievementsFrame();
     }
 
-	if (!RA_IsOverlayFullyVisible())
-	{
-		Gl::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		_video.draw();
-		SDL_GL_SwapWindow(_window);
-	}
+    if (!RA_IsOverlayFullyVisible())
+    {
+      Gl::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+      _video.draw();
+      SDL_GL_SwapWindow(_window);
+    }
 
     RA_HandleHTTPResults();
 


### PR DESCRIPTION
Depends on changes to RA_Interface.cpp. Need to switch the RAIntegration submodule to the `libretro_render` branch or wait for https://github.com/RetroAchievements/RAIntegration/pull/24 to be merged.