### PR TITLE
able to cross compile RALibretro on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,24 @@
+# IMPORTANT NOTE FOR CROSS-COMPILING:
+# you need to change your PATH to invoke the mingw-32bit flavor of sdl2-config
+
 # Toolset setup
-CC=gcc
-CXX=g++
-RC=windres
+ifeq ($(OS),Windows_NT)
+    CC=gcc
+    CXX=g++
+    RC=windres
+else ifeq ($(shell uname -s),Linux)
+    CC=i686-w64-mingw32-gcc
+    CXX=i686-w64-mingw32-g++
+    RC=i686-w64-mingw32-windres
+    STATICLIBS=-static-libstdc++ 
+endif
+
 INCLUDES=-Isrc -I./src/RA_Integration/src -I./src/RA_Integration/src/rapidjson/include
 DEFINES=-DOUTSIDE_SPEEX -DRANDOM_PREFIX=speex -DEXPORT= -D_USE_SSE2 -DFIXED_POINT
 CCFLAGS=-Wall -m32 $(INCLUDES) $(DEFINES) `sdl2-config --cflags`
 CXXFLAGS=$(CCFLAGS) -std=c++11
 LDFLAGS=-m32
+
 
 ifneq ($(DEBUG),)
   CFLAGS   += -O0 -g -DDEBUG_FSM -DLOG_TO_FILE
@@ -17,7 +29,7 @@ else
 endif
 
 # main
-LIBS=`sdl2-config --static-libs` -lopengl32 -lwinhttp
+LIBS=`sdl2-config --static-libs` $(STATICLIBS) -lopengl32 -lwinhttp
 OBJS=\
 	src/dynlib/dynlib.o \
 	src/jsonsax/jsonsax.o \
@@ -53,9 +65,9 @@ OBJS=\
 %.res: %.rc
 	$(RC) $< -O coff -o $@
 
-all: bin/RALibretro
+all: bin/RALibretro.exe
 
-bin/RALibretro: $(OBJS)
+bin/RALibretro.exe: $(OBJS)
 	mkdir -p bin
 	$(CXX) $(LDFLAGS) -o $@ $+ $(LIBS)
 


### PR DESCRIPTION
With this Makefile I am able to [cross-]compile RALibretro on Linux and Windows/MSYS2.

Regarding the compilation on Windows/MSYS2, it doesn't change anything. Everything works in the same way.

For cross compiling on Linux it's needed to have the toolchain for cross compiling (of course) and the SDL2 mingw development libraries installed (which can be found [here](https://www.libsdl.org/download-2.0.php)).

**NOTE**: looks like the `libstdc++-6.dll` provided by the `g++-mingw-w64-i686` package on Ubuntu-based distros is different than the one native from Windows. Then I had to use `-static-libstdc++` when cross compiling.

**EDIT**: I was having issues to launch RALibretro after cross-compiling, but solved it by using the static linking trick described above.