### PR TITLE
Enable loading FDS files

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -306,6 +306,13 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kNintendo:
     rom = util::loadFile(logger, path, &size);
     ok = romLoadedNes(rom, size);
+
+    if (!ok) // Assume FDS
+    {
+        RA_OnLoadNewRom((BYTE*)rom, size);
+        ok = true;
+    }
+
     free(rom);
     break;
   


### PR DESCRIPTION
FDS files cannot use the same parsing strategy as regular NES files. This solves the problem by falling back onto the default loading strategy if NES header parsing fails.