### PR TITLE
Add MSVC output files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /Debug
 /ipch
 /src/Git.cpp
+/src/menu.res
+/src/log.txt
 /*.db
 /RetroAchievementsKey
-/src/menu.res

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /bin/Screenshots
 /bin/System
 /RALibretro*.zip
+/obj
 /Debug
 /Release
 /ipch

--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,13 @@
 /bin/Assets
 /bin/Cores/*.json
 /bin/RACache
+/bin/Release
 /bin/Saves
 /bin/Screenshots
 /bin/System
 /RALibretro*.zip
 /obj
 /Debug
-/Release
 /ipch
 /src/Git.cpp
 /*.db


### PR DESCRIPTION
Based on Visual Studio 2017 output in both debug and release modes.