### PR TITLE
Fixed neogeo pocket linkage plus added Atari 7800

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -37,6 +37,7 @@ const char* getEmulatorName(Emulator emulator)
   case Emulator::kMednafenNgp:   return "Mednafen NGP";
   case Emulator::kMednafenVb:    return "Mednafen VB";
   case Emulator::kFBAlpha:       return "Final Burn Alpha";
+  case Emulator::kProSystem:     return "ProSystem";   
   default:                       break;
   }
   
@@ -61,6 +62,7 @@ const char* getEmulatorFileName(Emulator emulator)
   case Emulator::kMednafenNgp:   return "mednafen_ngp_libretro";
   case Emulator::kMednafenVb:    return "mednafen_vb_libretro";
   case Emulator::kFBAlpha:       return "fbalpha_libretro";
+  case Emulator::kProSystem:     return "prosystem_libretro";
   default:                       break;
   }
   
@@ -87,6 +89,7 @@ const char* getEmulatorExtensions(Emulator emulator)
   case Emulator::kMednafenNgp:   return EXTPREFIX "*.NGP;*.NGC;*.NGPC\0";                     // ngp|ngc|ngpc
   case Emulator::kMednafenVb:    return EXTPREFIX "*.VB;*.VBOY;*.BIN\0";                      // vb|vboy|bin
   case Emulator::kFBAlpha:       return EXTPREFIX "*.ZIP\0";                                  // iso|zip|7z
+  case Emulator::kProSystem:     return EXTPREFIX "*.A78\0";                                  // a78
   default:                       break;
   }
   
@@ -114,6 +117,7 @@ const char* getSystemName(System system)
   case System::kVirtualBoy:     return "Virtual Boy";
   case System::kGameGear:       return "Game Gear";
   case System::kArcade:         return "Arcade";
+  case System::kAtari7800:      return "Atari 7800";
   default:                      break;
   }
   
@@ -134,7 +138,7 @@ System getSystem(Emulator emulator, const std::string game_path, libretro::Core*
   case Emulator::kMednafenNgp: return System::kNeoGeoPocket;
   case Emulator::kMednafenVb:  return System::kVirtualBoy;
   case Emulator::kFBAlpha:     return System::kArcade;
-
+  case Emulator::kProSystem:   return System::kAtari7800;
   case Emulator::kPicoDrive:
   case Emulator::kGenesisPlusGx:
     if (core->getMemorySize(RETRO_MEMORY_SYSTEM_RAM) == 0x2000)
@@ -291,6 +295,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kMasterSystem:
   case System::kMegaDrive:
   case System::kSuperNintendo:
+  case System::kAtari7800:   
   default:
     RA_OnLoadNewRom((BYTE*)rom, size);
     ok = true;

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -42,7 +42,8 @@ enum class Emulator
   kMednafenPsx,
   kMednafenNgp,
   kMednafenVb,
-  kFBAlpha
+  kFBAlpha,
+  kProSystem
 };
 
 enum class System
@@ -59,10 +60,11 @@ enum class System
   kGameBoyColor   = GBC,
   kGameBoyAdvance = GBA,
   kPlayStation1   = PlayStation,
-  kNeoGeoPocket   = NeoGeo,
+  kNeoGeoPocket   = NeoGeoPocket,
   kVirtualBoy     = VirtualBoy,
   kGameGear       = GameGear,
-  kArcade         = Arcade
+  kArcade         = Arcade,
+  kAtari7800      = Atari7800
 };
 
 const char* getEmulatorName(Emulator emulator);

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -52,6 +52,7 @@ main MENU
             MENUITEM "PicoDrive (Master System, Mega Drive)", IDM_SYSTEM_PICODRIVE
             MENUITEM "Snes9x (Super Nintendo)", IDM_SYSTEM_SNES9X
             MENUITEM "Stella (Atari 2600)", IDM_SYSTEM_STELLA
+            MENUITEM "ProSystem (Atari 7800)", IDM_SYSTEM_PROSYSTEM
         }
         MENUITEM SEPARATOR
         MENUITEM "Load Game...", IDM_LOAD_GAME

--- a/src/resource.h
+++ b/src/resource.h
@@ -35,6 +35,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #define IDM_SYSTEM_MEDNAFENNGP                  50010
 #define IDM_SYSTEM_MEDNAFENVB                   50011
 #define IDM_SYSTEM_FBALPHA                      50012
+#define IDM_SYSTEM_PROSYSTEM                    50013
 
 // Keep those in increasing order
 #define IDM_SAVE_STATE_1                        51000


### PR DESCRIPTION
Fixed the rom linkage to neogeo pocket to wrong Category "Neo Geo" is used for CD, and added new one for Atari 7800 using ProSystem core.