### PR TITLE
Fixed neogeo pocket system name for proper console linkage

### DIFF
--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -59,7 +59,7 @@ enum class System
   kGameBoyColor   = GBC,
   kGameBoyAdvance = GBA,
   kPlayStation1   = PlayStation,
-  kNeoGeoPocket   = NeoGeo,
+  kNeoGeoPocket   = NeoGeoPocket,
   kVirtualBoy     = VirtualBoy,
   kGameGear       = GameGear,
   kArcade         = Arcade


### PR DESCRIPTION
This system name must be fixed, so it does link to proper console id 14 "Neo Geo Pocket" instead of 32 called "Neo Geo", that should be used for CD i suppose