### PR TITLE
properly load ROM data

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -612,23 +612,12 @@ void Application::updateMenu()
 
 bool Application::loadGame(const std::string& path)
 {
-  const struct retro_system_info* info = _core.getSystemInfo();
   size_t size;
-  void* data;
+  void* data = util::loadFile(&_logger, path, &size);
 
-  if (info->need_fullpath)
+  if (data == NULL)
   {
-    size = 0;
-    data = NULL;
-  }
-  else
-  {
-    data = util::loadFile(&_logger, path, &size);
-
-    if (data == NULL)
-    {
-      return false;
-    }
+    return false;
   }
 
   _system = getSystem(_emulator, path, &_core);

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -46,7 +46,7 @@ main MENU
             MENUITEM "Genesis Plus GX (Game Gear, Master System, Mega Drive)", IDM_SYSTEM_GENESISPLUSGX
             MENUITEM "Handy (Atari Lynx)", IDM_SYSTEM_HANDY
             MENUITEM "Mednafen NGP (Neo Geo Pocket)", IDM_SYSTEM_MEDNAFENNGP
-            MENUITEM "Mednafen PSX (PlayStation)", IDM_SYSTEM_MEDNAFENPSX
+            //MENUITEM "Mednafen PSX (PlayStation)", IDM_SYSTEM_MEDNAFENPSX
             MENUITEM "Mednafen VB (Virtual Boy)", IDM_SYSTEM_MEDNAFENVB
             MENUITEM "mGBA (Game Boy Advance)", IDM_SYSTEM_MGBA
             MENUITEM "PicoDrive (Master System, Mega Drive)", IDM_SYSTEM_PICODRIVE


### PR DESCRIPTION
I'm not 100% sure if [this checking is really needed](https://github.com/RetroAchievements/RALibretro/blob/9dd7d6264f17c0543b8c254157840a6d05700acb/src/Application.cpp#L619) - `if (info->need_fullpath)`. But it was making `data` to be always `NULL`, therefore generating the md5 checksum of an empty string: `d41d8cd98f00b204e9800998ecf8427e`.

I've tested this change with games for all supported cores and it works fine.

This issue started on this commit: 127a28784f5247acd757959a9a1f935c95aa8a2c, after the removal of [lines like this one](https://github.com/RetroAchievements/RALibretro/commit/127a28784f5247acd757959a9a1f935c95aa8a2c#diff-73463b17d9ee77f556b8ab8f50175adaL294).

It was **not** noticed in 1.0.7 (current released version) because the branch with the buggy commit had not yet been merged in the `master` branch (used to build the officially released version), but only in the `develop` one.

In this PR I'm also removing the "Mednafen PSX" from the "Select Core" menu.