### PR TITLE
load ROM data before RA_OnLoadNewRom() (and free memory right after)

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -292,7 +292,9 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kMegaDrive:
   case System::kSuperNintendo:
   default:
+    rom = util::loadFile(logger, path, &size);
     RA_OnLoadNewRom((BYTE*)rom, size);
+    free(rom);
     ok = true;
     break;
 
@@ -302,14 +304,18 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
     if (!ok)
     {
       // Fall back to the default strategy, assuming FDS file
+      rom = util::loadFile(logger, path, &size);
       RA_OnLoadNewRom((BYTE*)rom, size);
+      free(rom);
       ok = true;
     }
 
     break;
   
   case System::kAtariLynx:
+    rom = util::loadFile(logger, path, &size);
     RA_OnLoadNewRom((BYTE*)rom + 0x0040, size > 0x0240 ? 0x0200 : size - 0x0040);
+    free(rom);
     ok = true;
     break;
   

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -46,7 +46,7 @@ main MENU
             MENUITEM "Genesis Plus GX (Game Gear, Master System, Mega Drive)", IDM_SYSTEM_GENESISPLUSGX
             MENUITEM "Handy (Atari Lynx)", IDM_SYSTEM_HANDY
             MENUITEM "Mednafen NGP (Neo Geo Pocket)", IDM_SYSTEM_MEDNAFENNGP
-            MENUITEM "Mednafen PSX (PlayStation)", IDM_SYSTEM_MEDNAFENPSX
+            //MENUITEM "Mednafen PSX (PlayStation)", IDM_SYSTEM_MEDNAFENPSX
             MENUITEM "Mednafen VB (Virtual Boy)", IDM_SYSTEM_MEDNAFENVB
             MENUITEM "mGBA (Game Boy Advance)", IDM_SYSTEM_MGBA
             MENUITEM "PicoDrive (Master System, Mega Drive)", IDM_SYSTEM_PICODRIVE


### PR DESCRIPTION
This PR solves the issue started on commit 127a28784f5247acd757959a9a1f935c95aa8a2c. That commit removes [lines like this one](https://github.com/RetroAchievements/RALibretro/commit/127a28784f5247acd757959a9a1f935c95aa8a2c#diff-73463b17d9ee77f556b8ab8f50175adaL294), and in this PR I'm putting them back where they are still necessary.

(Thanks @Jamiras for pointing where the problem is.)

I've tested this change with games for all supported cores and it works fine.

It was **not** noticed in 1.0.7 (current released version) because the branch with the buggy commit had not yet been merged in the `master` branch (used to build the officially released version), but only in the `develop` one.

In this PR I'm also removing the "Mednafen PSX" from the "Select Core" menu.