### PR TITLE
include CHR data in NES hash

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -38,17 +38,6 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAG "[UTL] "
 
-size_t util::nextPow2(size_t v)
-{
-  v--;
-  v |= v >> 1;
-  v |= v >> 2;
-  v |= v >> 4;
-  v |= v >> 8;
-  v |= v >> 16;
-  return v + 1;
-}
-
 void* util::loadFile(Logger* logger, const std::string& path, size_t* size)
 {
   void* data;

--- a/src/Util.h
+++ b/src/Util.h
@@ -29,7 +29,6 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace util
 {
-  size_t      nextPow2(size_t v);
   void*       loadFile(Logger* logger, const std::string& path, size_t* size);
   bool        saveFile(Logger* logger, const std::string& path, const void* data, size_t size);
   std::string jsonEscape(const std::string& str);


### PR DESCRIPTION
Tested with several headered NES ROMs, and one FDS ROM. 

Headerless ROM still does not work. The FCEUMM core doesn't support headerless ROMs:
> [WARN] Missing header or invalid iNES format file!

This solution also eliminates the need for the power of 2 rounding required by original hashing (FCEUX would read Action 52 as a 2MB PRG, even though it's only 1.5MB).
