### PR TITLE
don't collapse memory if region has size but not data

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -828,12 +828,11 @@ moved_recent_item:
           }
         }
 
-        if (layout[i].len != 0)
+        if (layout[i].len != 0 && layout[i].ptr)
         {
           registerMemoryRegion(&numBanks, 0, layout[i].ptr, layout[i].len);
+          address = layout[i].start + layout[i].len;
         }
-
-        address = layout[i].start + layout[i].len;
       }
 
       delete[] layout;


### PR DESCRIPTION
Using the game "Asterix & Obelix", the value of $BFFE differs when running in RAVBA-M and RAlibretro with the Gambatte core.

![image](https://user-images.githubusercontent.com/32680403/49698731-e3266800-fb84-11e8-8b5d-f5dcbb2cbe25.png)

The problem seems to be that particular ROM doesn't have any cartridge RAM, so when the Gambatte core reports memory info for the $A000-$BFFF region, it specifies a size, but not a pointer. As a result, the memory region is not registered with the toolkit, so the next memory region (starting at $C000) appears as $A000. The highlighted value (seen at $BFFE in RAlibretro) is present in RAVBA-M, but at $DFFE, which is the correct address.

This fix simply ignores regions without any supporting memory, so the "fill" logic will kick in. There's still a small difference between RAVBA-M and RAlibretro - RAVBA-M reports the missing memory as FFs, RAlibretro fills it with 00s. This difference shouldn't affect anything, as achievements should not be looking for either.