### PR TITLE
Display an error message on load failure for all cores

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -635,13 +635,10 @@ bool Application::loadGame(const std::string& path)
     
   if (!_core.loadGame(path.c_str(), data, size))
   {
-    if (_system == System::kNintendo)
-    {
-      // Assume that the FDS system is missing
-      _logger.debug(TAG "Game load failure (Nintendo)");
+    // The most common cause of failure is missing system files.
+    _logger.debug(TAG "Game load failure (%s)", info ? info->library_name : "Unknown");
 
-      MessageBox(g_mainWindow, "Game load error. Are you missing a system file?", "Core Error", MB_OK);
-    }
+    MessageBox(g_mainWindow, "Game load error. Please ensure that requires system files are present and restart.", "Core Error", MB_OK);
 
     if (data)
     {


### PR DESCRIPTION
I believe multiple cores require system files, and since a load failure results in a subsequent crash (#39), we should tell the user to restart regardless of where the problem comes from.