### PR TITLE
Support headerless Lynx files

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -320,7 +320,16 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   
   case System::kAtariLynx:
     rom = util::loadFile(logger, path, &size);
-    RA_OnLoadNewRom((BYTE*)rom + 0x0040, size > 0x0240 ? 0x0200 : size - 0x0040);
+
+    if (!strcmp("LYNX", (char *)rom))
+    {
+        RA_OnLoadNewRom((BYTE*)rom + 0x0040, size - 0x0040);
+    }
+    else
+    {
+        RA_OnLoadNewRom((BYTE*)rom, size);
+    }
+
     free(rom);
     ok = true;
     break;

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -321,7 +321,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kAtariLynx:
     rom = util::loadFile(logger, path, &size);
 
-    if (!strcmp("LYNX", (char *)rom))
+    if (!memcmp("LYNX", (void *)rom, 5))
     {
         RA_OnLoadNewRom((BYTE*)rom + 0x0040, size - 0x0040);
     }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -81,7 +81,7 @@ const char* getEmulatorExtensions(Emulator emulator)
   case Emulator::kPicoDrive:     return EXTPREFIX "*.BIN;*.GEN;*.SMD;*.MD;*.SMS\0";           // bin|gen|smd|md|32x|cue|iso|sms
   case Emulator::kGenesisPlusGx: return EXTPREFIX "*.BIN;*.GEN;*.SMD;*.MD;*.SMS;*.GG;*.SG\0"; // mdx|md|smd|gen|bin|cue|iso|chd|sms|gg|sg
   case Emulator::kFceumm:        return EXTPREFIX "*.FDS;*.NES;*.UNF;*.UNIF\0";               // fds|nes|unf|unif
-  case Emulator::kHandy:         return EXTPREFIX "*.LNX\0";                                  // lnx
+  case Emulator::kHandy:         return EXTPREFIX "*.LYX;*.LNX\0";                            // lyx|lnx
   case Emulator::kBeetleSgx:     return EXTPREFIX "*.PCE;*.SGX;*.CUE;*.CCD;*.CHD\0";          // pce|sgx|cue|ccd|chd
   case Emulator::kGambatte:      return EXTPREFIX "*.GB;*.GBC;*.DMG\0";                       // gb|gbc|dmg
   case Emulator::kMGBA:          return EXTPREFIX "*.GBA\0";                                  // gba|gb|gbc


### PR DESCRIPTION
This PR checks the existence of a valid header to skip it if it is present, and hashes the rest of the file. With an untouched rip the resulting hash matches databases.

I also removed a file size check, because it is redundant (no commercial Lynx release exceeds 512KB), potentially error-inducing (if homebrew releases exceed that size) and confusing.

Please update https://github.com/RetroAchievements/docs/wiki/Game-Identification/ once merged/released.

I also have a RetroArch PR that I will send after this one is processed.