### PR TITLE
listing Konami/Cave/Psikyo as supported by fbalpha

### DIFF
--- a/src/menu.rc
+++ b/src/menu.rc
@@ -41,7 +41,7 @@ main MENU
         {
             MENUITEM "Beetle SGX (PC Engine)", IDM_SYSTEM_BEETLESGX
             MENUITEM "FCEUmm (Nintendo)", IDM_SYSTEM_FCEUMM
-            MENUITEM "Final Burn Alpha (Neo Geo, CPS1, CPS2, CPS3)", IDM_SYSTEM_FBALPHA
+            MENUITEM "Final Burn Alpha (Neo Geo, CPS1/2/3, Konami, Cave, Psikyo)", IDM_SYSTEM_FBALPHA
             MENUITEM "Gambatte (Game Boy, Game Boy Color)", IDM_SYSTEM_GAMBATTE
             MENUITEM "Genesis Plus GX (Game Gear, Master System, Mega Drive)", IDM_SYSTEM_GENESISPLUSGX
             MENUITEM "Handy (Atari Lynx)", IDM_SYSTEM_HANDY


### PR DESCRIPTION
Just a small change on the menu listing Konami, Cave and Psikyo as supported arcade boards:

![arcadeboards](https://user-images.githubusercontent.com/8508804/51231810-e5ca6900-194b-11e9-8991-e36af2f41e3a.png)
