### PR TITLE
Revert "listing Konami/Cave/Psikyo as supported by fbalpha"

### DIFF
--- a/src/menu.rc
+++ b/src/menu.rc
@@ -41,7 +41,7 @@ main MENU
         {
             MENUITEM "Beetle SGX (PC Engine)", IDM_SYSTEM_BEETLESGX
             MENUITEM "FCEUmm (Nintendo)", IDM_SYSTEM_FCEUMM
-            MENUITEM "Final Burn Alpha (Neo Geo, CPS1/2/3, Konami, Cave, Psikyo)", IDM_SYSTEM_FBALPHA
+            MENUITEM "Final Burn Alpha (Neo Geo, CPS1, CPS2, CPS3)", IDM_SYSTEM_FBALPHA
             MENUITEM "Gambatte (Game Boy, Game Boy Color)", IDM_SYSTEM_GAMBATTE
             MENUITEM "Genesis Plus GX (Game Gear, Master System, Mega Drive)", IDM_SYSTEM_GENESISPLUSGX
             MENUITEM "Handy (Atari Lynx)", IDM_SYSTEM_HANDY


### PR DESCRIPTION
Reverts RetroAchievements/RALibretro#61

Many Cave/Psikyo games are vertical shmups and RALibretro doesn't rotate the screen properly.

Also, @JuliaWolska (aka Salsa) reported that many Konami games are unstable.

That being said, maybe it's better to not advertise the support for those boards so soon.