### PR TITLE
[WIP] add blueMSX core for ColecoVision support

### DIFF
--- a/dl-cores.bat
+++ b/dl-cores.bat
@@ -12,7 +12,7 @@ FOR %%A IN (%1 %2 %3) DO (
 )
 
 SET SUPPORTED_CORES=fbalpha fceumm gambatte genesis_plus_gx handy mednafen_ngp ^
-mednafen_supergrafx mednafen_vb mgba picodrive snes9x stella prosystem
+mednafen_supergrafx mednafen_vb mgba picodrive snes9x stella prosystem bluemsx
 SET NIGHTLY_URL="https://buildbot.libretro.com/nightly/windows/x86/latest"
 SET DEST_DIR=bin\Cores
 SET DEPS=wget unzip

--- a/dl-cores.sh
+++ b/dl-cores.sh
@@ -12,7 +12,7 @@
 SUPPORTED_CORES=(
     fbalpha fceumm gambatte genesis_plus_gx handy mednafen_ngp
     mednafen_supergrafx mednafen_vb mgba picodrive snes9x stella
-    prosystem
+    prosystem bluemsx
 )
 NIGHTLY_URL="https://buildbot.libretro.com/nightly/windows/x86/latest"
 DEST_DIR="bin/Cores"

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -741,6 +741,7 @@ moved_recent_item:
   case Emulator::kMednafenNgp:
   case Emulator::kFBAlpha:
   case Emulator::kProSystem:
+  case Emulator::kblueMSX:
     data = _core.getMemoryData(RETRO_MEMORY_SYSTEM_RAM);
     size = _core.getMemorySize(RETRO_MEMORY_SYSTEM_RAM);
     registerMemoryRegion(&numBanks, 0, data, size);
@@ -1594,12 +1595,13 @@ void Application::handle(const SDL_SysWMEvent* syswm)
     case IDM_SYSTEM_MEDNAFENVB:
     case IDM_SYSTEM_FBALPHA:
     case IDM_SYSTEM_PROSYSTEM:
+    case IDM_SYSTEM_BLUEMSX:
       {
         static Emulator emulators[] =
         {
           Emulator::kStella, Emulator::kSnes9x, Emulator::kPicoDrive, Emulator::kGenesisPlusGx, Emulator::kFceumm,
           Emulator::kHandy, Emulator::kBeetleSgx, Emulator::kGambatte, Emulator::kMGBA, Emulator::kMednafenPsx,
-          Emulator::kMednafenNgp, Emulator::kMednafenVb, Emulator::kFBAlpha, Emulator::kProSystem
+          Emulator::kMednafenNgp, Emulator::kMednafenVb, Emulator::kFBAlpha, Emulator::kProSystem, Emulator::kblueMSX
         };
 
         _fsm.loadCore(emulators[cmd - IDM_SYSTEM_STELLA]);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -92,7 +92,7 @@ const char* getEmulatorExtensions(Emulator emulator)
   case Emulator::kMednafenVb:    return EXTPREFIX "*.VB;*.VBOY;*.BIN\0";                      // vb|vboy|bin
   case Emulator::kFBAlpha:       return EXTPREFIX "*.ZIP\0";                                  // iso|zip|7z
   case Emulator::kProSystem:     return EXTPREFIX "*.A78\0";                                  // a78
-  case Emulator::kblueMSX:       return EXTPREFIX "*.BIN\0";                                  // bin
+  case Emulator::kblueMSX:       return EXTPREFIX "*.BIN;*.COL;*.ROM\0";                      // bin|col|rom
   default:                       break;
   }
   

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -38,6 +38,7 @@ const char* getEmulatorName(Emulator emulator)
   case Emulator::kMednafenVb:    return "Mednafen VB";
   case Emulator::kFBAlpha:       return "Final Burn Alpha";
   case Emulator::kProSystem:     return "ProSystem";
+  case Emulator::kblueMSX:       return "blueMSX";
   default:                       break;
   }
   
@@ -63,6 +64,7 @@ const char* getEmulatorFileName(Emulator emulator)
   case Emulator::kMednafenVb:    return "mednafen_vb_libretro";
   case Emulator::kFBAlpha:       return "fbalpha_libretro";
   case Emulator::kProSystem:     return "prosystem_libretro";
+  case Emulator::kblueMSX:       return "bluemsx_libretro";
   default:                       break;
   }
   
@@ -90,6 +92,7 @@ const char* getEmulatorExtensions(Emulator emulator)
   case Emulator::kMednafenVb:    return EXTPREFIX "*.VB;*.VBOY;*.BIN\0";                      // vb|vboy|bin
   case Emulator::kFBAlpha:       return EXTPREFIX "*.ZIP\0";                                  // iso|zip|7z
   case Emulator::kProSystem:     return EXTPREFIX "*.A78\0";                                  // a78
+  case Emulator::kblueMSX:       return EXTPREFIX "*.BIN\0";                                  // bin
   default:                       break;
   }
   
@@ -118,6 +121,7 @@ const char* getSystemName(System system)
   case System::kGameGear:       return "Game Gear";
   case System::kArcade:         return "Arcade";
   case System::kAtari7800:      return "Atari 7800";
+  case System::kColecoVision:   return "ColecoVision";
   default:                      break;
   }
   
@@ -139,6 +143,7 @@ System getSystem(Emulator emulator, const std::string game_path, libretro::Core*
   case Emulator::kMednafenVb:  return System::kVirtualBoy;
   case Emulator::kFBAlpha:     return System::kArcade;
   case Emulator::kProSystem:   return System::kAtari7800;
+  case Emulator::kblueMSX:     return System::kColecoVision;
 
   case Emulator::kPicoDrive:
   case Emulator::kGenesisPlusGx:
@@ -264,6 +269,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kMasterSystem:
   case System::kMegaDrive:
   case System::kAtari7800:
+  case System::kColecoVision:
   default:
     rom = util::loadFile(logger, path, &size);
     RA_OnLoadNewRom((BYTE*)rom, size);

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -43,7 +43,8 @@ enum class Emulator
   kMednafenNgp,
   kMednafenVb,
   kFBAlpha,
-  kProSystem
+  kProSystem,
+  kblueMSX
 };
 
 enum class System
@@ -64,7 +65,8 @@ enum class System
   kVirtualBoy     = VirtualBoy,
   kGameGear       = GameGear,
   kArcade         = Arcade,
-  kAtari7800      = Atari7800
+  kAtari7800      = Atari7800,
+  kColecoVision   = Colecovision
 };
 
 const char* getEmulatorName(Emulator emulator);

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -53,6 +53,7 @@ main MENU
             MENUITEM "Snes9x (Super Nintendo)", IDM_SYSTEM_SNES9X
             MENUITEM "Stella (Atari 2600)", IDM_SYSTEM_STELLA
             MENUITEM "ProSystem (Atari 7800)", IDM_SYSTEM_PROSYSTEM
+            MENUITEM "blueMSX (ColecoVision)", IDM_SYSTEM_BLUEMSX
         }
         MENUITEM SEPARATOR
         MENUITEM "Load Game...", IDM_LOAD_GAME

--- a/src/resource.h
+++ b/src/resource.h
@@ -36,6 +36,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #define IDM_SYSTEM_MEDNAFENVB                   50011
 #define IDM_SYSTEM_FBALPHA                      50012
 #define IDM_SYSTEM_PROSYSTEM                    50013
+#define IDM_SYSTEM_BLUEMSX                      50014
 
 // Keep those in increasing order
 #define IDM_SAVE_STATE_1                        51000


### PR DESCRIPTION
The changes in this PR are not yet enough to make ColecoVision games be playable on RALibretro+blueMSX.

You'll have to follow these steps to get the BIOS files: https://docs.libretro.com/library/bluemsx/#bios

> ## BIOS
>
>The blueMSX core requires the 'Databases' and 'Machines' folders from a full installation of blueMSX.
>
>You can download the 'Databases' and 'Machines' folders from an [official full standalone blueMSX emulator installation](http://bluemsx.msxblue.com/download.html). Get blueMSXv282full.zip near the bottom of the page.
>
>Move/Copy the 'Databases' and 'Machines' Folders to RetroArch's System directory.
>
>![](https://github.com/libretro/docs/raw/master/docs/image/core/bluemsx/bios.png)

But instead, put those folders in the RALibretro's `System` directory.

After that I was able to (kinda) launch the Venture game. The ROM is recognized, the achievements are loaded (I can see them in `RetroAchievements` > `Achievement Sets` dialog box), **but nothing happens on the emulated screen** (completely black).