### PR TITLE
support for zipped ROMs (implements #4)

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -613,17 +613,63 @@ void Application::updateMenu()
 bool Application::loadGame(const std::string& path)
 {
   const struct retro_system_info* info = _core.getSystemInfo();
+  std::string unzippedFileName;
+  const char* ptr;
   size_t size;
   void* data;
+  bool loaded;
+  bool iszip = (path.length() > 4 && stricmp(&path.at(path.length() - 4), ".zip") == 0);
+  bool issupportedzip = false;
 
-  if (info->need_fullpath)
+  /* if the core says it wants the full path, we have to see if it supports zip files */
+  if (iszip && info->need_fullpath)
+  {
+    ptr = info->valid_extensions;
+    while (*ptr)
+    {
+      if (strnicmp(ptr, "zip", 3) == 0 && (ptr[3] == '\0' || ptr[3] == '|'))
+      {
+        issupportedzip = true;
+        break;
+      }
+
+      while (*ptr && *ptr != '|')
+      {
+        ++ptr;
+      }
+      if (*ptr == '|')
+      {
+        ++ptr;
+      }
+    }
+
+    if (!issupportedzip)
+    {
+      _logger.debug(TAG "%s does not support zip files", info->library_name);
+
+      std::string error = info->library_name;
+      error += " does not support zip files";
+      MessageBox(g_mainWindow, error.c_str(), "Core Error", MB_OK);
+
+      return false;
+    }
+  }
+
+  if (issupportedzip)
   {
     size = 0;
     data = NULL;
   }
-  else
+  else 
   {
-    data = util::loadFile(&_logger, path, &size);
+    if (iszip)
+    {
+      data = util::loadZippedFile(&_logger, path, &size, unzippedFileName);
+    }
+    else
+    {
+      data = util::loadFile(&_logger, path, &size);
+    }
 
     if (data == NULL)
     {
@@ -631,9 +677,21 @@ bool Application::loadGame(const std::string& path)
     }
   }
 
-  _system = getSystem(_emulator, path, &_core);
-    
-  if (!_core.loadGame(path.c_str(), data, size))
+  if (unzippedFileName.empty())
+  {
+    unzippedFileName = util::fileNameWithExtension(path);
+  }
+
+  if (info->need_fullpath)
+  {
+    loaded = _core.loadGame(path.c_str(), NULL, 0);
+  }
+  else
+  {
+    loaded = _core.loadGame(path.c_str(), data, size);
+  }
+
+  if (!loaded)
   {
     // The most common cause of failure is missing system files.
     _logger.debug(TAG "Game load failure (%s)", info ? info->library_name : "Unknown");
@@ -647,7 +705,9 @@ bool Application::loadGame(const std::string& path)
 
     return false;
   }
-  
+
+  _system = getSystem(_emulator, unzippedFileName, &_core);
+
   RA_SetConsoleID((unsigned)_system);
   RA_ClearMemoryBanks();
 
@@ -669,6 +729,7 @@ bool Application::loadGame(const std::string& path)
   }
 
   _gamePath = path;
+  _gameFileName = unzippedFileName;
 
   for (size_t i = 0; i < _recentList.size(); i++)
   {
@@ -995,6 +1056,8 @@ bool Application::unloadGame()
     util::saveFile(&_logger, sram.c_str(), data, size);
   }
 
+  RA_OnLoadNewRom(NULL, 0);
+
   return true;
 }
 
@@ -1097,7 +1160,43 @@ void Application::s_audioCallback(void* udata, Uint8* stream, int len)
 
 void Application::loadGame()
 {
-  std::string path = util::openFileDialog(g_mainWindow, getEmulatorExtensions(_emulator));
+  const struct retro_system_info* info = _core.getSystemInfo();
+  std::string file_types;
+  std::string supported_exts;
+  const char* ext = info->valid_extensions;
+  const char* ptr = ext;
+
+  while (*ptr)
+  {
+    supported_exts += "*.";
+    while (*ptr && *ptr != '|')
+      supported_exts += *ptr++;
+
+    if (!*ptr)
+      break;
+
+    supported_exts += ';';
+    ++ptr;
+  }
+
+  if (!info->need_fullpath)
+  {
+    supported_exts += ";*.zip";
+  }
+
+  file_types.reserve(supported_exts.size() * 2 + 32);
+  file_types.append("All Files (*.*)");
+  file_types.append("\0", 1);
+  file_types.append("*.*");
+  file_types.append("\0", 1);
+  file_types.append("Supported Files (");
+  file_types.append(supported_exts);
+  file_types.append(")");
+  file_types.append("\0", 1);
+  file_types.append(supported_exts);
+  file_types.append("\0", 1);
+
+  std::string path = util::openFileDialog(g_mainWindow, file_types.c_str());
 
   if (!path.empty())
   {
@@ -1193,24 +1292,7 @@ void Application::registerMemoryRegion(unsigned* max, unsigned bank, void* data,
 std::string Application::getSRamPath()
 {
   std::string path = _config.getSaveDirectory();
-
-  size_t last_slash = _gamePath.find_last_of("/");
-  size_t last_bslash = _gamePath.find_last_of("\\");
-
-  if (last_bslash > last_slash || last_slash == std::string::npos)
-  {
-    last_slash = last_bslash;
-  }
-
-  if (last_slash == std::string::npos)
-  {
-    path += _gamePath;
-  }
-  else
-  {
-    path += _gamePath.substr(last_slash);
-  }
-  
+  path += _gameFileName;
   path += ".sram";
   return path;
 }
@@ -1218,23 +1300,7 @@ std::string Application::getSRamPath()
 std::string Application::getStatePath(unsigned ndx)
 {
   std::string path = _config.getSaveDirectory();
-
-  size_t last_slash = _gamePath.find_last_of("/");
-  size_t last_bslash = _gamePath.find_last_of("\\");
-
-  if (last_bslash > last_slash || last_slash == std::string::npos)
-  {
-    last_slash = last_bslash;
-  }
-
-  if (last_slash == std::string::npos)
-  {
-    path += _gamePath;
-  }
-  else
-  {
-    path += _gamePath.substr(last_slash);
-  }
+  path += _gameFileName;
 
   path += "-";
   path += getEmulatorFileName(_emulator);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -624,7 +624,10 @@ bool Application::loadGame(const std::string& path)
   /* if the core says it wants the full path, we have to see if it supports zip files */
   if (iszip && info->need_fullpath)
   {
-    ptr = info->valid_extensions;
+    ptr = getEmulatorExtensions(_emulator);
+    if (ptr == NULL)
+      ptr = info->valid_extensions;
+
     while (*ptr)
     {
       if (strnicmp(ptr, "zip", 3) == 0 && (ptr[3] == '\0' || ptr[3] == '|'))
@@ -1163,8 +1166,9 @@ void Application::loadGame()
   const struct retro_system_info* info = _core.getSystemInfo();
   std::string file_types;
   std::string supported_exts;
-  const char* ext = info->valid_extensions;
-  const char* ptr = ext;
+  const char* ptr = getEmulatorExtensions(_emulator);
+  if (ptr == NULL)
+    ptr = info->valid_extensions;
 
   while (*ptr)
   {

--- a/src/Application.h
+++ b/src/Application.h
@@ -141,6 +141,7 @@ protected:
   libretro::Core       _core;
 
   std::string _gamePath;
+  std::string _gameFileName;
   unsigned    _validSlots;
 
   MemoryBank _memoryBanks[2];

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -69,35 +69,6 @@ const char* getEmulatorFileName(Emulator emulator)
   return "?";
 }
 
-const char* getEmulatorExtensions(Emulator emulator)
-{
-#define EXTPREFIX "All Files\0*.*\0Supported Files\0"
-
-  switch (emulator)
-  {
-  case Emulator::kNone:          break;
-  case Emulator::kStella:        return EXTPREFIX "*.A26;*.BIN\0";                            // a26|bin
-  case Emulator::kSnes9x:        return EXTPREFIX "*.SMC;*.SFC;*.SWC;*.FIG\0";                // smc|sfc|swc|fig
-  case Emulator::kPicoDrive:     return EXTPREFIX "*.BIN;*.GEN;*.SMD;*.MD;*.SMS\0";           // bin|gen|smd|md|32x|cue|iso|sms
-  case Emulator::kGenesisPlusGx: return EXTPREFIX "*.BIN;*.GEN;*.SMD;*.MD;*.SMS;*.GG;*.SG\0"; // mdx|md|smd|gen|bin|cue|iso|chd|sms|gg|sg
-  case Emulator::kFceumm:        return EXTPREFIX "*.FDS;*.NES;*.UNF;*.UNIF\0";               // fds|nes|unf|unif
-  case Emulator::kHandy:         return EXTPREFIX "*.LYX;*.LNX\0";                            // lyx|lnx
-  case Emulator::kBeetleSgx:     return EXTPREFIX "*.PCE;*.SGX;*.CUE;*.CCD;*.CHD\0";          // pce|sgx|cue|ccd|chd
-  case Emulator::kGambatte:      return EXTPREFIX "*.GB;*.GBC;*.DMG\0";                       // gb|gbc|dmg
-  case Emulator::kMGBA:          return EXTPREFIX "*.GBA\0";                                  // gba|gb|gbc
-  case Emulator::kMednafenPsx:   return EXTPREFIX "*.*\0";
-  case Emulator::kMednafenNgp:   return EXTPREFIX "*.NGP;*.NGC;*.NGPC\0";                     // ngp|ngc|ngpc
-  case Emulator::kMednafenVb:    return EXTPREFIX "*.VB;*.VBOY;*.BIN\0";                      // vb|vboy|bin
-  case Emulator::kFBAlpha:       return EXTPREFIX "*.ZIP\0";                                  // iso|zip|7z
-  case Emulator::kProSystem:     return EXTPREFIX "*.A78\0";                                  // a78
-  default:                       break;
-  }
-  
-  return "?";
-
-#undef EXTPREFIX
-}
-
 const char* getSystemName(System system)
 {
   switch (system)
@@ -265,9 +236,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   case System::kMegaDrive:
   case System::kAtari7800:
   default:
-    rom = util::loadFile(logger, path, &size);
     RA_OnLoadNewRom((BYTE*)rom, size);
-    free(rom);
     ok = true;
     break;
 
@@ -280,18 +249,15 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
     break;
   
   case System::kAtariLynx:
-    rom = util::loadFile(logger, path, &size);
-
     if (!memcmp("LYNX", (void *)rom, 5))
     {
-        RA_OnLoadNewRom((BYTE*)rom + 0x0040, size - 0x0040);
+      RA_OnLoadNewRom((BYTE*)rom + 0x0040, size - 0x0040);
     }
     else
     {
-        RA_OnLoadNewRom((BYTE*)rom, size);
+      RA_OnLoadNewRom((BYTE*)rom, size);
     }
 
-    free(rom);
     ok = true;
     break;
   

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -69,6 +69,20 @@ const char* getEmulatorFileName(Emulator emulator)
   return "?";
 }
 
+const char* getEmulatorExtensions(Emulator emulator)
+{
+  /* provide filtered lists for cores that support filetypes that aren't fully RetroAchievement compatible */
+  switch (emulator)
+  {
+    case Emulator::kPicoDrive:     return "bin|gen|smd|md|sms";       // bin|gen|smd|md|32x|cue|iso|sms
+    case Emulator::kGenesisPlusGx: return "bin|gen|smd|md|sms|gg|sg"; // mdx|md|smd|gen|bin|cue|iso|chd|sms|gg|sg
+    case Emulator::kMGBA:          return "gba";                      // gba|gb|gbc
+    case Emulator::kFBAlpha:       return "zip";                      // iso|zip|7z
+    default:
+      return NULL;
+  }
+}
+
 const char* getSystemName(System system)
 {
   switch (system)

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -69,7 +69,6 @@ enum class System
 
 const char* getEmulatorName(Emulator emulator);
 const char* getEmulatorFileName(Emulator emulator);
-const char* getEmulatorExtensions(Emulator emulator);
 const char* getSystemName(System system);
 
 System getSystem(Emulator emulator, const std::string game_path, libretro::Core* core);

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -69,6 +69,7 @@ enum class System
 
 const char* getEmulatorName(Emulator emulator);
 const char* getEmulatorFileName(Emulator emulator);
+const char* getEmulatorExtensions(Emulator emulator);
 const char* getSystemName(System system);
 
 System getSystem(Emulator emulator, const std::string game_path, libretro::Core* core);

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -140,6 +140,10 @@
     <ClCompile Include="libretro\BareCore.cpp" />
     <ClCompile Include="libretro\Core.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="miniz\miniz.c" />
+    <ClCompile Include="miniz\miniz_tdef.c" />
+    <ClCompile Include="miniz\miniz_tinfl.c" />
+    <ClCompile Include="miniz\miniz_zip.c" />
     <ClCompile Include="RA_Implementation.cpp" />
     <ClCompile Include="RA_Integration\src\RA_Interface.cpp" />
     <ClCompile Include="speex\resample.c" />

--- a/src/RALibretro.vcxproj.filters
+++ b/src/RALibretro.vcxproj.filters
@@ -13,6 +13,24 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
     </Filter>
+    <Filter Include="Source Files\jsonsax">
+      <UniqueIdentifier>{a6cdf81f-2031-4895-96cf-2fefe335ed43}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dynlib">
+      <UniqueIdentifier>{321f2861-5b70-4141-a843-8a7d704a5624}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\miniz">
+      <UniqueIdentifier>{c6bd24ca-4aa5-4eed-8f4f-0dbd5fd5f845}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\libretro">
+      <UniqueIdentifier>{2e31befd-421f-451b-b48f-be36a52c02ca}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\speex">
+      <UniqueIdentifier>{d1aeaa60-23b8-4d0c-af9d-025f837827b9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\RA_Integration">
+      <UniqueIdentifier>{327760fa-a82f-4fc7-a522-359086500937}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="About.cpp">
@@ -39,40 +57,22 @@
     <ClCompile Include="components\Video.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="dynlib\dynlib.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Emulator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Fsm.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="jsonsax\jsonsax.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="KeyBinds.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="libretro\BareCore.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="libretro\Core.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="main.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="speex\resample.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Gl.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_Integration\src\RA_Interface.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="RA_Implementation.cpp">
@@ -83,6 +83,36 @@
     </ClCompile>
     <ClCompile Include="GlUtil.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="jsonsax\jsonsax.c">
+      <Filter>Source Files\jsonsax</Filter>
+    </ClCompile>
+    <ClCompile Include="dynlib\dynlib.c">
+      <Filter>Source Files\dynlib</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz_zip.c">
+      <Filter>Source Files\miniz</Filter>
+    </ClCompile>
+    <ClCompile Include="libretro\BareCore.cpp">
+      <Filter>Source Files\libretro</Filter>
+    </ClCompile>
+    <ClCompile Include="libretro\Core.cpp">
+      <Filter>Source Files\libretro</Filter>
+    </ClCompile>
+    <ClCompile Include="speex\resample.c">
+      <Filter>Source Files\speex</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Integration\src\RA_Interface.cpp">
+      <Filter>Source Files\RA_Integration</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz.c">
+      <Filter>Source Files\miniz</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz_tinfl.c">
+      <Filter>Source Files\miniz</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz_tdef.c">
+      <Filter>Source Files\miniz</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Util.h
+++ b/src/Util.h
@@ -30,10 +30,12 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 namespace util
 {
   void*       loadFile(Logger* logger, const std::string& path, size_t* size);
+  void*       loadZippedFile(Logger* logger, const std::string& path, size_t* size, std::string& unzippedFileName);
   bool        saveFile(Logger* logger, const std::string& path, const void* data, size_t size);
   std::string jsonEscape(const std::string& str);
   std::string jsonUnescape(const std::string& str);
   std::string fileName(const std::string& path);
+  std::string fileNameWithExtension(const std::string& path);
   std::string extension(const std::string& path);
   std::string openFileDialog(HWND hWnd, const char* extensionsFilter);
   std::string saveFileDialog(HWND hWnd, const char* extensionsFilter);


### PR DESCRIPTION
Relies on the core's `info->need_fullpath` parameter. If that is false, we can unzip the file and load it directly into the core. If it's true, we have to let the core tell us which files it supports. The "Open Game" dialog will include 'zip' in the "Supported Files" selection if the core supports the functionality.

NOTE: if a zip file contains more than one file or any sort of directory structure, it will not load. The zip processing logic is very simple.

The following cores now support zip files:
* FCEUmm
* Gambatte
* Mednafen VB
* mGBA
* Snes9x
* Stella
* ProSystem

The following cores still do not support zip files:
* Beetle SGX
* Genesis Plus GX
* Handy
* Mednafen NGP
* PicoDrive

NOTE: PicoDrive says it needs the full path, so this code prevents loading zip files for that core, but it's the only currently supported core that has `info->need_fullpath` and supports passing the unzipped file (I tried them all). As such, the feature is not enabled for that core.

Additionally, FBA requires a zip file, but _does not_ unzip it. This is also handled by the `info->need_fullpath` value, which FBA also has set to true, but since 'zip' is a supported extension in `info->valid_extensions`, no error is displayed.

[RALibretro-zipped-roms.zip](https://github.com/RetroAchievements/RALibretro/files/2873866/RALibretro-zipped-roms.zip)
