### PR TITLE
Complete checklist for RALibRetro

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -714,8 +714,12 @@ bool Application::loadGame(const std::string& path)
   RA_SetConsoleID((unsigned)_system);
   RA_ClearMemoryBanks();
 
+  _gameFileName = unzippedFileName; // store for GetEstimatedTitle callback
+
   if (!romLoaded(&_logger, _system, path, data, size))
   {
+    _gameFileName.clear();
+
     _core.unloadGame();
 
     if (data)
@@ -732,7 +736,6 @@ bool Application::loadGame(const std::string& path)
   }
 
   _gamePath = path;
-  _gameFileName = unzippedFileName;
 
   for (size_t i = 0; i < _recentList.size(); i++)
   {

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1069,7 +1069,20 @@ bool Application::unloadGame()
 
 void Application::pauseGame(bool pause)
 {
-  RA_SetPaused(pause);
+  if (!pause)
+  {
+    _fsm.resumeGame();
+    RA_SetPaused(false);
+  }
+  else if (hardcore())
+  {
+    _fsm.pauseGame();
+    RA_SetPaused(true);
+  }
+  else
+  {
+    _fsm.pauseGameNoOvl();
+  }
 }
 
 void Application::printf(const char* fmt, ...)
@@ -1835,10 +1848,16 @@ void Application::handle(const SDL_KeyboardEvent* key)
     if (_fsm.currentState() == Fsm::State::GamePaused)
     {
       _fsm.resumeGame();
+      RA_SetPaused(false);
+    }
+    else if (_fsm.currentState() == Fsm::State::GamePausedNoOvl)
+    {
+      _fsm.resumeGame();
     }
     else
     {
       _fsm.pauseGame();
+      RA_SetPaused(true);
     }
 
     break;

--- a/src/Application.h
+++ b/src/Application.h
@@ -64,6 +64,7 @@ public:
   unsigned char memoryRead(unsigned bank, unsigned addr);
   void memoryWrite(unsigned bank, unsigned addr, unsigned value);
   bool isGameActive();
+  const std::string& gameName() const { return _gameFileName; }
 
 protected:
   struct MemoryRegion

--- a/src/Fsm.cpp
+++ b/src/Fsm.cpp
@@ -719,14 +719,7 @@ bool Fsm::pauseGame() {
 
         return false;
       }
-
-
-      if (ctx.hardcore()) {
-        return false;
-      }
-
-      ctx.pauseGame(true);
-    
+ 
       __state = State::GamePaused;
       after(__state);
       after();
@@ -754,14 +747,7 @@ bool Fsm::pauseGame() {
 
         return false;
       }
-
-
-      if (ctx.hardcore()) {
-        return false;
-      }
-
-      ctx.pauseGame(true);
-    
+   
       __state = State::GamePaused;
       after(__state);
       after();
@@ -1254,9 +1240,6 @@ bool Fsm::resumeGame() {
 
         return false;
       }
-
-
-      ctx.pauseGame(false);
     
       __state = State::GameRunning;
       after(__state);

--- a/src/Fsm.cpp
+++ b/src/Fsm.cpp
@@ -1305,6 +1305,10 @@ bool Fsm::step() {
         return false;
       }
 
+      if (ctx.hardcore()) {
+          return false;
+      }
+
       __state = State::FrameStep;
       after(__state);
       after();
@@ -1331,6 +1335,10 @@ bool Fsm::step() {
 #endif
 
         return false;
+      }
+
+      if (ctx.hardcore()) {
+          return false;
       }
 
       __state = State::FrameStep;
@@ -1394,6 +1402,10 @@ bool Fsm::step() {
         return false;
       }
 
+      if (ctx.hardcore()) {
+          return false;
+      }
+
       __state = State::FrameStep;
       after(__state);
       after();
@@ -1430,11 +1442,6 @@ bool Fsm::turbo() {
         return false;
       }
 
-
-      if (ctx.hardcore()) {
-        return false;
-      }
-    
       __state = State::GameTurbo;
       after(__state);
       after();
@@ -1462,12 +1469,7 @@ bool Fsm::turbo() {
 
         return false;
       }
-
-
-      if (ctx.hardcore()) {
-        return false;
-      }
-    
+   
       __state = State::GameTurbo;
       after(__state);
       after();
@@ -1493,11 +1495,6 @@ bool Fsm::turbo() {
         ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
 #endif
 
-        return false;
-      }
-
-
-      if (ctx.hardcore()) {
         return false;
       }
     

--- a/src/Fsm.fsm
+++ b/src/Fsm.fsm
@@ -17,6 +17,41 @@ You should have received a copy of the GNU General Public License
 along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/*
+
+To generate Fsm.h and Fsm.cpp from this file:
+
+[Windows]
+* install lua
+  - download lua-5.2.4.tar.gz (http://www.lua.org/ftp/) and extract somewhere [it must be a 5.2 version]
+  - open MinGW 64-bit and change to the folder where you extracted the tar.gz
+  - run `make clean`, `make mingw` and `make install TO_BIN="lua.exe luac.exe lua52.dll"`
+  - verify install:
+    $ lua -e "print('hello world')"
+    hello world
+  - remove extracted files; they're not needed anymore
+* install luarocks
+  - download the latest ".win32.zip" not the ".windows-32.zip" (http://luarocks.github.io/luarocks/releases/) and extract it
+  - open an elevated command prompt and change into the extracted folder
+  - run `install.bat /lv 5.2 /bin c:\msys64\usr\local\bin /lib c:\msys64\usr\local\bin /inc c:\msys64\usr\local\include`
+* install luasrcdiet
+  - open an elevated command promot and change into the luarocks install folder (C:\Program Files (x86)\LuaRocks)
+  - run `luarocks.bat install luasrcdiet`
+* build ddlt
+  - clone the https://github.com/leiradel/ddlt repository
+  - open MinGW 64-bit and change to the cloned repository folder
+  - manually run luasrcdiet as it was not installed under the MinGW context:
+    `$ /c/Program\ Files\ \(x86\)/LuaRocks/bin/luasrcdiet.bat --noopt-emptylines src/boot.lua -o src/boot_diet.lua`
+  - edit the Makefile to point to the correct lua locations:
+    `INCLUDES=-Isrc -I/usr/local/include`
+	`LUALIB=/usr/local/bin/lua52.dll`
+  - allow make to do the rest of the work: `make`
+* generate the FSM files:
+  - from MinGW 64-bit console (in the ddlt repository):
+    `lua examples/fsmc/fsmc.lua /e/source/RALibRetro/src/Fsm.fsm`
+  - this will generate the Fsm.h and Fsm.cpp files in the same directory as the Fsm.fsm file.
+*/
+
 header {
   #include "Emulator.h"
   #include <string>
@@ -64,13 +99,7 @@ fsm Fsm {
   }
 
   GameRunning {
-    pauseGame() => GamePaused {
-      if (ctx.hardcore()) {
-        forbid;
-      }
-
-      ctx.pauseGame(true);
-    }
+    pauseGame() => GamePaused;
 
     pauseGameNoOvl() => GamePausedNoOvl {
       if (ctx.hardcore()) {
@@ -88,11 +117,7 @@ fsm Fsm {
       }
     }
     
-    turbo() => GameTurbo {
-      if (ctx.hardcore()) {
-        forbid;
-      }
-    }
+    turbo() => GameTurbo;
 
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
@@ -110,19 +135,17 @@ fsm Fsm {
   }
 
   GamePaused {
-    resumeGame() => GameRunning {
-      ctx.pauseGame(false);
-    }
+    resumeGame() => GameRunning;
 
     resetGame() => resumeGame() => resetGame();
 
-    step() => FrameStep;
-    
-    turbo() => GameTurbo {
+    step() => FrameStep  {
       if (ctx.hardcore()) {
         forbid;
       }
     }
+
+    turbo() => GameTurbo;
 
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
@@ -144,13 +167,13 @@ fsm Fsm {
 
     resetGame() => resumeGame() => resetGame();
 
-    step() => FrameStep;
-    
-    turbo() => GameTurbo {
+    step() => FrameStep {
       if (ctx.hardcore()) {
         forbid;
       }
     }
+
+    turbo() => GameTurbo;
 
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
@@ -182,15 +205,13 @@ fsm Fsm {
       }
     }
 
-    step() => FrameStep;
-    
-    pauseGame() => GamePaused {
+    step() => FrameStep {
       if (ctx.hardcore()) {
         forbid;
       }
-
-      ctx.pauseGame(true);
     }
+
+    pauseGame() => GamePaused;
 
     pauseGameNoOvl() => GamePausedNoOvl {
       if (ctx.hardcore()) {

--- a/src/RA_Implementation.cpp
+++ b/src/RA_Implementation.cpp
@@ -1,11 +1,13 @@
 #include "RA_Integration/RA_Implementation/RA_Implementation.h"
 #include "RA_Interface.h"
+
 #include <windows.h>
 
 
 extern HWND g_mainWindow;
 
 bool isGameActive();
+void getGameName(char name[], size_t len);
 void pause();
 void resume();
 void reset();
@@ -80,6 +82,7 @@ void RebuildMenu()
 //   for the ROM, if one can be inferred from the ROM.
 void GetEstimatedGameTitle(char* sNameOut)
 {
+    getGameName(sNameOut, 64);
 }
 
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -92,7 +92,6 @@ void* util::loadZippedFile(Logger* logger, const std::string& path, size_t* size
   mz_zip_archive_file_stat file_stat;
   void* data;
   int file_count;
-  int i;
 
   memset(&zip_archive, 0, sizeof(zip_archive));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,13 @@ bool isGameActive()
   return app.isGameActive();
 }
 
+void getGameName(char name[], size_t len)
+{
+    std::string fileName = util::fileName(app.gameName());
+    strncpy(name, fileName.c_str(), len);
+    name[len - 1] = '\0';
+}
+
 void pause()
 {
   app.pauseGame(true);


### PR DESCRIPTION
* pass ROM name to unknown game dialog
* make Pause on Reset/Trigger actually pause the emulator
* allow turbo in hardcore
* don't allow stepping when paused in hardcore

also updated the RAIntegration version to pick up the fix for the 12005 error

[RALibRetro-checklist.txt](https://github.com/RetroAchievements/RALibretro/files/3164791/RALibRetro-1.0.15.txt)
