### PR TITLE
don't log DEBUG messages in release build

### DIFF
--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -40,6 +40,10 @@ bool Logger::init()
   _file = fopen("log.txt", "w");
 #endif
 
+#ifndef NDEBUG
+  setLogLevel(RETRO_LOG_DEBUG);
+#endif
+
   return true;
 }
 

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -40,6 +40,11 @@ namespace libretro
   public:
     virtual void vprintf(enum retro_log_level level, const char* fmt, va_list args) = 0;
 
+    void setLogLevel(enum retro_log_level level)
+    {
+      _level = level;
+    }
+
     void printf(enum retro_log_level level, const char* fmt, ...)
     {
       va_list args;
@@ -50,6 +55,9 @@ namespace libretro
 
     void debug(const char* fmt, ...)
     {
+      if (_level > RETRO_LOG_DEBUG)
+        return;
+
       va_list args;
       va_start(args, fmt);
       vprintf(RETRO_LOG_DEBUG, fmt, args);
@@ -58,6 +66,9 @@ namespace libretro
 
     void info(const char* fmt, ...)
     {
+      if (_level > RETRO_LOG_INFO)
+        return;
+
       va_list args;
       va_start(args, fmt);
       vprintf(RETRO_LOG_INFO, fmt, args);
@@ -66,6 +77,9 @@ namespace libretro
 
     void warn(const char* fmt, ...)
     {
+      if (_level > RETRO_LOG_WARN)
+        return;
+
       va_list args;
       va_start(args, fmt);
       vprintf(RETRO_LOG_WARN, fmt, args);
@@ -79,6 +93,9 @@ namespace libretro
       vprintf(RETRO_LOG_ERROR, fmt, args);
       va_end(args);
     }
+
+  private:
+    enum retro_log_level _level = RETRO_LOG_INFO;
   };
 
   /**


### PR DESCRIPTION
After a couple hours of play, my `log.txt` file was over 40MB:
```
$ ls -l log.txt
-rw-r--r-- 1 user user 43566131 Aug  5 17:57 log.txt
```
It was primarily filled with this over and over:
```
[DEBUG] [BRE] Calling libretro::BareCore::run
[DEBUG] [CRE] Calling GET_VARIABLE_UPDATE (17)
[DEBUG] [CRE] Called  GET_VARIABLE_UPDATE (17) -> 1
[DEBUG] [VID] Texture refreshed with 700 x 240 pixels
[DEBUG] [BRE] Called  libretro::BareCore::run
[DEBUG] [AUD] Requested 737 audio frames
[DEBUG] [AUD] Original ratio 1.088435 adjusted by 0.996765 to 1.084914
[DEBUG] [AUD] Resampling 1474 samples to 1600
[DEBUG] [AUD] Resampled  1470 samples to 1600
[DEBUG] [AUD] Requested 3200 bytes but only 2892 available, sleeping
[DEBUG] [AUD] Requested 3200 bytes but only 2892 available, sleeping
[DEBUG] [AUD] Requested 3200 bytes but only 2892 available, sleeping
[DEBUG] [AUD] Audio hardware requested 4096 bytes
[DEBUG] [AUD] Wrote 3200 bytes to the FIFO
```
Over 99% of the file was DEBUG messages:
```
$ wc -l  log.txt
845074 log.txt
$ grep -v "[DEBUG]" log.txt | wc -l
13
```
Most users will never look at this file, so there's no reason to take the time (or space) to write all that debug information.

This PR adds a level flag to the `LoggerComponent`. The default has been changed to INFO for non-debug builds and DEBUG for debug builds.
