### PR TITLE
use multiple columns in core settings dialog if more than 16 variables exist

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1966,7 +1966,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       break;
       
     case IDM_CORE_CONFIG:
-      _config.showDialog();
+      _config.showDialog(_core.getSystemInfo()->library_name);
       break;
 
     case IDM_INPUT_CONFIG:

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -50,7 +50,7 @@ public:
 
   std::string serialize();
   void deserialize(const char* json);
-  void showDialog();
+  void showDialog(const std::string& coreName);
 
 protected:
   static const char* s_getOption(int index, void* udata);

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -100,14 +100,14 @@ main MENU
     }
     POPUP "Settings"
     {
-        MENUITEM "Emulation", IDM_CORE_CONFIG
+        MENUITEM "Core Settings...", IDM_CORE_CONFIG
         POPUP "Input"
         {
-            MENUITEM "Hot Keys", IDM_INPUT_CONFIG
-            MENUITEM "Controller 1", IDM_INPUT_CONTROLLER_1
-            MENUITEM "Controller 2", IDM_INPUT_CONTROLLER_2
+            MENUITEM "Hot Keys...", IDM_INPUT_CONFIG
+            MENUITEM "Controller 1...", IDM_INPUT_CONTROLLER_1
+            MENUITEM "Controller 2...", IDM_INPUT_CONTROLLER_2
         }
-        MENUITEM "Video", IDM_VIDEO_CONFIG
+        MENUITEM "Video...", IDM_VIDEO_CONFIG
         POPUP "Window Size"
         {
             MENUITEM "Resize to 1x", IDM_WINDOW_1X


### PR DESCRIPTION
Changes
![image](https://user-images.githubusercontent.com/32680403/62788875-093e3800-ba85-11e9-87ad-16504461a3c5.png)

To
![image](https://user-images.githubusercontent.com/32680403/62788879-0cd1bf00-ba85-11e9-9ff2-0507b6ed3994.png)

Also note the dialog title now reflects the currently loaded core.