### PR TITLE
support for unicode paths

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -707,6 +707,7 @@ bool Application::loadGame(const std::string& path)
 
     if (data == NULL)
     {
+      MessageBox(g_mainWindow, "Unable to open file", "Error", MB_OK);
       return false;
     }
   }
@@ -730,7 +731,7 @@ bool Application::loadGame(const std::string& path)
     // The most common cause of failure is missing system files.
     _logger.debug(TAG "Game load failure (%s)", info ? info->library_name : "Unknown");
 
-    MessageBox(g_mainWindow, "Game load error. Please ensure that requires system files are present and restart.", "Core Error", MB_OK);
+    MessageBox(g_mainWindow, "Game load error. Please ensure that required system files are present and restart.", "Core Error", MB_OK);
 
     if (data)
     {
@@ -773,7 +774,7 @@ bool Application::loadGame(const std::string& path)
   else
   {
     char names[10][128];
-    int count = cdrom_get_cd_names(path.c_str(), names, sizeof(names) / sizeof(names[0]));
+    int count = cdrom_get_cd_names(path.c_str(), names, sizeof(names) / sizeof(names[0]), &_logger);
     updateCDMenu(names, count, true);
   }
 
@@ -1244,7 +1245,7 @@ void Application::loadGame()
   file_types.append(supported_exts);
   file_types.append("\0", 1);
 
-  std::string path = util::openFileDialog(g_mainWindow, file_types.c_str());
+  std::string path = util::openFileDialog(g_mainWindow, file_types);
 
   if (!path.empty())
   {
@@ -1520,7 +1521,9 @@ void Application::saveState(unsigned ndx)
 
 void Application::saveState()
 {
-  std::string path = util::saveFileDialog(g_mainWindow, "*.STATE\0");
+  std::string extensions = "*.STATE";
+  extensions.append("\0", 1);
+  std::string path = util::saveFileDialog(g_mainWindow, extensions);
 
   if (!path.empty())
   {
@@ -1593,7 +1596,9 @@ void Application::loadState(unsigned ndx)
 
 void Application::loadState()
 {
-  std::string path = util::openFileDialog(g_mainWindow, "*.STATE\0");
+  std::string extensions = "*.STATE";
+  extensions.append("\0", 1);
+  std::string path = util::openFileDialog(g_mainWindow, extensions);
 
   if (path.empty())
   {
@@ -1643,7 +1648,7 @@ void Application::buildSystemsMenu()
   std::map<std::string, System> systemMap;
   std::map<std::string, int> systemItems;
   for (auto system : availableSystems)
-    systemMap.insert_or_assign(getSystemName(system), system);
+    systemMap.emplace(getSystemName(system), system);
 
   HMENU fileMenu = GetSubMenu(_menu, 0);
   HMENU systemsMenu = GetSubMenu(fileMenu, 0);
@@ -1663,7 +1668,7 @@ void Application::buildSystemsMenu()
     for (const auto& systemCore : systemCores)
     {
       int id = encodeCoreName(systemCore, pair.second);
-      systemItems.insert_or_assign(getEmulatorName(systemCore, system), id);
+      systemItems.emplace(getEmulatorName(systemCore, system), id);
     }
 
     HMENU systemMenu = CreateMenu();

--- a/src/CdRom.h
+++ b/src/CdRom.h
@@ -19,6 +19,8 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "components/Logger.h"
+
 #include <stdio.h>
 
 struct cdrom_t
@@ -29,10 +31,10 @@ struct cdrom_t
   int sector_remaining;
 };
 
-bool cdrom_open(cdrom_t& cdrom, const char* filename, int disc, int track);
+bool cdrom_open(cdrom_t& cdrom, const char* filename, int disc, int track, Logger* logger);
 void cdrom_close(cdrom_t& cdrom);
 
 bool cdrom_seek_file(cdrom_t& cdrom, const char* filename);
 int cdrom_read(cdrom_t& cdrom, void* buffer, int num_bytes);
 
-int cdrom_get_cd_names(const char* filename, char names[][128], int max_names);
+int cdrom_get_cd_names(const char* filename, char names[][128], int max_names, Logger* logger);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -91,11 +91,13 @@ bool loadCores(Config* config, Logger* logger)
     CoreInfo* core;
     std::string key;
     Config* config;
+    Logger* logger;
   };
 
   Deserialize ud;
   ud.core = NULL;
   ud.config = config;
+  ud.logger = logger;
 
   jsonsax_parse((char*)data, &ud, [](void* udata, jsonsax_event_t event, const char* str, size_t num)
   {
@@ -108,7 +110,7 @@ bool loadCores(Config* config, Logger* logger)
       std::string path = ud->config->getRootFolder();
       path += "Cores\\" + ud->key + ".dll";
 
-      FILE* file = fopen(path.c_str(), "r");
+      FILE* file = util::openFile(ud->logger, path, "r");
       if (file)
       {
         fclose(file);
@@ -321,7 +323,7 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
   uint8_t* exe_raw;
   int size, remaining;
 
-  if (!cdrom_open(cdrom, path.c_str(), 1, 1))
+  if (!cdrom_open(cdrom, path.c_str(), 1, 1, logger))
     return false;
 
   exe_name = NULL;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -31,6 +31,8 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include <shlobj.h>
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
+#define STBI_MSC_SECURE_CRT
+#define STBI_WRITE_NO_STDIO
 #define STBIW_ASSERT(x)
 #include "stb_image_write.h"
 
@@ -40,46 +42,70 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAG "[UTL] "
 
-void* util::loadFile(Logger* logger, const std::string& path, size_t* size)
+FILE* util::openFile(Logger* logger, const std::string& path, const char* mode)
 {
-  void* data;
-  struct stat statbuf;
-
-  if (stat(path.c_str(), &statbuf) != 0)
+  FILE* file;
+  bool isAscii = true;
+  for (const char c : path)
   {
-    logger->error(TAG "Error getting info from \"%s\": %s", path.c_str(), strerror(errno));
-    return NULL;
+    if (c & 0x80)
+    {
+      isAscii = false;
+      break;
+    }
   }
 
-  *size = statbuf.st_size;
-  data = malloc(*size + 1);
+  errno_t err;
+  if (isAscii)
+  {
+    err = fopen_s(&file, path.c_str(), mode);
+  }
+  else
+  {
+    std::wstring unicodePath = util::utf8ToUChar(path);
+    std::wstring unicodeMode = util::utf8ToUChar(mode);
+    err = _wfopen_s(&file, unicodePath.c_str(), unicodeMode.c_str());
+  }
 
+  if (err)
+  {
+    char buffer[256];
+    strerror_s(buffer, sizeof(buffer), err);
+    logger->error(TAG "Error opening \"%s\": %s", path.c_str(), buffer);
+    file = NULL;
+  }
+
+  return file;
+}
+
+void* util::loadFile(Logger* logger, const std::string& path, size_t* size)
+{
+  FILE* file = util::openFile(logger, path, "rb");
+  if (file == NULL)
+    return NULL;
+
+  fseek(file, 0, SEEK_END);
+  *size = ftell(file);
+
+  void* data = malloc(*size + 1);
   if (data == NULL)
   {
+    fclose(file);
     logger->error(TAG "Out of memory allocating %lu bytes to load \"%s\"", *size, path.c_str());
     return NULL;
   }
 
-  FILE* file = fopen(path.c_str(), "rb");
-
-  if (file == NULL)
-  {
-    logger->error(TAG "Error opening \"%s\": %s", path.c_str(), strerror(errno));
-    free(data);
-    return NULL;
-  }
-
+  fseek(file, 0, SEEK_SET);
   size_t numread = fread(data, 1, *size, file);
+  fclose(file);
 
   if (numread < 0 || numread != *size)
   {
     logger->error(TAG "Error reading \"%s\": %s", path.c_str(), strerror(errno));
-    fclose(file);
     free(data);
     return NULL;
   }
 
-  fclose(file);
   *((uint8_t*)data + *size) = 0;
   logger->info(TAG "Read %zu bytes from \"%s\"", *size, path.c_str());
   return data;
@@ -131,7 +157,7 @@ void* util::loadZippedFile(Logger* logger, const std::string& path, size_t* size
     return NULL;
   }
 
-  *size = file_stat.m_uncomp_size;
+  *size = (size_t)file_stat.m_uncomp_size;
   data = malloc(*size);
 
   status = mz_zip_reader_extract_to_mem(&zip_archive, 0, data, *size, 0);
@@ -151,13 +177,9 @@ void* util::loadZippedFile(Logger* logger, const std::string& path, size_t* size
 
 bool util::saveFile(Logger* logger, const std::string& path, const void* data, size_t size)
 {
-  FILE* file = fopen(path.c_str(), "wb");
-
+  FILE* file = util::openFile(logger, path, "wb");
   if (file == NULL)
-  {
-    logger->error(TAG "Error opening file \"%s\": %s", path.c_str(), strerror(errno));
     return false;
-  }
 
   if (fwrite(data, 1, size, file) != size)
   {
@@ -253,7 +275,7 @@ std::string util::fileNameWithExtension(const std::string& path)
 std::string util::fileName(const std::string& path)
 {
   std::string filename = fileNameWithExtension(path);
-  int ndx = filename.find_last_of('.');
+  const auto ndx = filename.find_last_of('.');
   if (ndx != std::string::npos)
     filename.resize(ndx);
 
@@ -278,7 +300,7 @@ std::string util::extension(const std::string& path)
 std::string util::replaceFileName(const std::string& originalPath, const char* newFileName)
 {
   std::string newPath = originalPath;
-  const int ndx = newPath.find_last_of('\\');
+  const auto ndx = newPath.find_last_of('\\');
   if (ndx == std::string::npos)
     return newFileName;
 
@@ -286,26 +308,27 @@ std::string util::replaceFileName(const std::string& originalPath, const char* n
   return newPath;
 }
 
-std::string util::openFileDialog(HWND hWnd, const char* extensionsFilter)
+std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)
 {
-  char path[_MAX_PATH];
+  std::wstring unicodeExtensionsFilter = util::utf8ToUChar(extensionsFilter);
+  wchar_t path[_MAX_PATH];
   path[0] = 0;
 
-  OPENFILENAME cfg;
+  OPENFILENAMEW cfg;
 
   cfg.lStructSize = sizeof(cfg);
   cfg.hwndOwner = hWnd;
   cfg.hInstance = NULL;
-  cfg.lpstrFilter = extensionsFilter;
+  cfg.lpstrFilter = unicodeExtensionsFilter.c_str();
   cfg.lpstrCustomFilter = NULL;
   cfg.nMaxCustFilter = 0;
   cfg.nFilterIndex = 2;
   cfg.lpstrFile = path;
-  cfg.nMaxFile = sizeof(path);
+  cfg.nMaxFile = sizeof(path)/sizeof(path[0]);
   cfg.lpstrFileTitle = NULL;
   cfg.nMaxFileTitle = 0;
   cfg.lpstrInitialDir = NULL;
-  cfg.lpstrTitle = "Load";
+  cfg.lpstrTitle = L"Load";
   cfg.Flags = OFN_FILEMUSTEXIST;
   cfg.nFileOffset = 0;
   cfg.nFileExtension = 0;
@@ -314,9 +337,9 @@ std::string util::openFileDialog(HWND hWnd, const char* extensionsFilter)
   cfg.lpfnHook = NULL;
   cfg.lpTemplateName = NULL;
 
-  if (GetOpenFileName(&cfg) == TRUE)
+  if (GetOpenFileNameW(&cfg) == TRUE)
   {
-    return path;
+    return util::ucharToUtf8(path);
   }
   else
   {
@@ -324,26 +347,27 @@ std::string util::openFileDialog(HWND hWnd, const char* extensionsFilter)
   }
 }
 
-std::string util::saveFileDialog(HWND hWnd, const char* extensionsFilter)
+std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter)
 {
-  char path[_MAX_PATH];
+  std::wstring unicodeExtensionsFilter = util::utf8ToUChar(extensionsFilter);
+  wchar_t path[_MAX_PATH];
   path[0] = 0;
 
-  OPENFILENAME cfg;
+  OPENFILENAMEW cfg;
 
   cfg.lStructSize = sizeof(cfg);
   cfg.hwndOwner = hWnd;
   cfg.hInstance = NULL;
-  cfg.lpstrFilter = extensionsFilter;
+  cfg.lpstrFilter = unicodeExtensionsFilter.c_str();
   cfg.lpstrCustomFilter = NULL;
   cfg.nMaxCustFilter = 0;
   cfg.nFilterIndex = 2;
   cfg.lpstrFile = path;
-  cfg.nMaxFile = sizeof(path);
+  cfg.nMaxFile = sizeof(path)/sizeof(path[0]);
   cfg.lpstrFileTitle = NULL;
   cfg.nMaxFileTitle = 0;
   cfg.lpstrInitialDir = NULL;
-  cfg.lpstrTitle = "Save";
+  cfg.lpstrTitle = L"Save";
   cfg.Flags = OFN_NOREADONLYRETURN | OFN_OVERWRITEPROMPT;
   cfg.nFileOffset = 0;
   cfg.nFileExtension = 0;
@@ -352,9 +376,9 @@ std::string util::saveFileDialog(HWND hWnd, const char* extensionsFilter)
   cfg.lpfnHook = NULL;
   cfg.lpTemplateName = NULL;
 
-  if (GetSaveFileName(&cfg) == TRUE)
+  if (GetSaveFileNameW(&cfg) == TRUE)
   {
-    return path;
+    return util::ucharToUtf8(path);
   }
   else
   {
@@ -460,10 +484,23 @@ void util::saveImage(Logger* logger, const std::string& path, const void* data, 
     return;
   }
 
-  stbi_write_png(path.c_str(), width, height, 3, pixels, 0);
-  free((void*)pixels);
+  int len;
+  unsigned char* png = stbi_write_png_to_mem((unsigned char*)pixels, 0, width, height, 3, &len);
+  if (png)
+  {
+    FILE* f = util::openFile(logger, path, "wb");
+    if (f)
+    {
+      fwrite(png, 1, len, f);
+      fclose(f);
 
-  logger->info(TAG "Wrote image %u x %u to %s", width, height, path.c_str());
+      logger->info(TAG "Wrote image %u x %u to %s", width, height, path.c_str());
+    }
+
+    STBIW_FREE(png);
+  }
+
+  free((void*)pixels);
 }
 
 const void* util::fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format)
@@ -579,8 +616,19 @@ const void* util::fromRgb(Logger* logger, const void* data, unsigned width, unsi
 
 const void* util::loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch)
 {
+  FILE* f = util::openFile(logger, path, "rb");
+  if (!f)
+  {
+    *width = 0;
+    *height = 0;
+    *pitch = 0;
+    return NULL;
+  }
+
   int w, h;
-  void* rgb888 = stbi_load(path.c_str(), &w, &h, NULL, STBI_rgb);
+  void* rgb888 = stbi_load_from_file(f, &w, &h, NULL, STBI_rgb);
+
+  fclose(f);
 
   logger->info(TAG "Read image %u x %u from %s", w, h, path.c_str());
 
@@ -589,4 +637,28 @@ const void* util::loadImage(Logger* logger, const std::string& path, unsigned* w
   *pitch = w * 3;
 
   return rgb888;
+}
+
+std::string util::ucharToUtf8(const std::wstring& unicodeString)
+{
+  const auto len = unicodeString.length();
+  const auto needed = WideCharToMultiByte(CP_UTF8, 0, unicodeString.c_str(), len + 1, nullptr, 0, nullptr, nullptr);
+
+  std::string str(needed, '\0');
+  WideCharToMultiByte(CP_UTF8, 0, unicodeString.c_str(), len + 1, (LPSTR)str.data(), str.capacity(), nullptr, nullptr);
+  str.resize(needed - 1); // terminator is not actually part of the string
+
+  return str;
+}
+
+std::wstring util::utf8ToUChar(const std::string& utf8String)
+{
+  const auto len = utf8String.length();
+  const auto needed = MultiByteToWideChar(CP_UTF8, 0, utf8String.c_str(), len + 1, nullptr, 0);
+
+  std::wstring wstr(needed, '\0');
+  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8String.c_str(), len + 1, (LPWSTR)wstr.data(), wstr.capacity());
+  wstr.resize(needed - 1); // terminator is not actually part of the string
+
+  return wstr;
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -29,6 +29,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace util
 {
+  FILE*       openFile(Logger* logger, const std::string& path, const char* mode);
   void*       loadFile(Logger* logger, const std::string& path, size_t* size);
   void*       loadZippedFile(Logger* logger, const std::string& path, size_t* size, std::string& unzippedFileName);
   bool        saveFile(Logger* logger, const std::string& path, const void* data, size_t size);
@@ -38,10 +39,12 @@ namespace util
   std::string fileNameWithExtension(const std::string& path);
   std::string extension(const std::string& path);
   std::string replaceFileName(const std::string& originalPath, const char* newFileName);
-  std::string openFileDialog(HWND hWnd, const char* extensionsFilter);
-  std::string saveFileDialog(HWND hWnd, const char* extensionsFilter);
+  std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter);
+  std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter);
   const void* toRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void        saveImage(Logger* logger, const std::string& path, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   const void* fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format);
   const void* loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch);
+  std::string ucharToUtf8(const std::wstring& unicodeString);
+  std::wstring utf8ToUChar(const std::string& utf8String);
 }


### PR DESCRIPTION
libretro cores support unicode paths in the form of UTF-8. `fopen` and `GetOpenFileName` do not.

When a user tried to load a game from a path containing unicode characters, `GetOpenFileName` would convert the unicode characters to question marks, and `fopen` would not be able to find the file.

This PR replaces `GetOpenFileName` with `GetOpenFileNameW`, so we get back a path containing unicode characters when selecting a game to load. That is then converted to UTF-8 so it can be passed to the core. Additionally, everything previously calling `fopen` now calls `util::openFile`, which will detect the non-ASCII characters and convert the UTF-8 path back to unicode and call `wfopen`.

I've modified the `stbi_` calls to use `util::openFile`, so save state images can also be properly generated/read from paths containing unicode characters.

Unfortunately, the miniz library does not support passing a FILE*, so zipped ROMs cannot currently be loaded from paths containing unicode characters. I've added a generic error when loading fails so the user is at least informed that something went wrong, even if it's not clear what.