### PR TITLE
reset activeGame when unloading game

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1090,7 +1090,7 @@ bool Application::unloadGame()
     util::saveFile(&_logger, sram.c_str(), data, size);
   }
 
-  RA_OnLoadNewRom(NULL, 0);
+  romUnloaded(&_logger);
 
   return true;
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -470,3 +470,9 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
 
   return ok;
 }
+
+void romUnloaded(Logger* logger)
+{
+  RA_DeactivateDisc();
+  RA_ActivateGame(0);
+}

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -62,5 +62,5 @@ void   getSystemCores(System system, std::set<std::string>& coreNames);
 int    encodeCoreName(const std::string& coreName, System system);
 const std::string& getCoreName(int encoded, System& system);
 
-System getSystem(const std::string& core_name, const std::string& game_path, libretro::Core* core);
 bool   romLoaded(Logger* logger, System system, const std::string& path, void* rom, size_t size);
+void   romUnloaded(Logger* logger);


### PR DESCRIPTION
fixes issue where toolkit editors were disabled when reloading the current game to refresh leaderboard data.