### PR TITLE
process some frames without rendering them to maintain framerate

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1553,7 +1553,7 @@ void Application::loadState(const std::string& path)
   free(data);
   RA_OnLoadState(path.c_str());
 
-  updateCDMenu(NULL, 0, true);
+  updateCDMenu(NULL, 0, false);
 
   unsigned width, height, pitch;
   enum retro_pixel_format format;

--- a/src/Application.h
+++ b/src/Application.h
@@ -90,6 +90,9 @@ protected:
   static void s_audioCallback(void* udata, Uint8* stream, int len);
 
   // Helpers
+  void        processEvents();
+  void        runSmoothed();
+
   void        loadGame();
   void        enableItems(const UINT* items, size_t count, UINT enable);
   void        enableSlots();

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -82,6 +82,8 @@ void Video::draw()
 {
   if (_texture != 0)
   {
+    Gl::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
     Gl::useProgram(_program);
 
     Gl::enableVertexAttribArray(_posAttribute);

--- a/src/libretro/BareCore.cpp
+++ b/src/libretro/BareCore.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include <stddef.h>
 #include <string.h>
 
-#define TAG "[BRE] "
+#define TAG "[BCR] "
 
 #define CORE_DLSYM(prop, name) \
   do { \

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -53,6 +53,9 @@ namespace libretro
       va_end(args);
     }
 
+#ifdef NDEBUG
+    void debug(const char* fmt, ...) {}
+#else
     void debug(const char* fmt, ...)
     {
       if (_level > RETRO_LOG_DEBUG)
@@ -63,6 +66,7 @@ namespace libretro
       vprintf(RETRO_LOG_DEBUG, fmt, args);
       va_end(args);
     }
+#endif
 
     void info(const char* fmt, ...)
     {

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 
 #define SAMPLE_COUNT 8192
 
-#define TAG "[CRE] "
+#define TAG "[COR] "
 
 /**
  * Unavoidable because the libretro API don't have an userdata pointer to
@@ -606,6 +606,7 @@ bool libretro::Core::shutdown()
 
 bool libretro::Core::setPerformanceLevel(unsigned data)
 {
+  _logger->info(TAG "Performance level %u reported", data);
   _performanceLevel = data;
   return true;
 }
@@ -1482,7 +1483,7 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
       _calls[cmd / 8] |= 1 << (cmd & 7);
     }
 
-    ret = false;
+    return false;
   }
 
   if (ret)


### PR DESCRIPTION
If a core indicates a RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL higher than 10, gameplay rendering switches to a rendering loop that keeps track of how long it takes to process and render each frame. If the render rate is not at least 55 fps, some renders will be dropped to try to keep the processing rate about 55 fps. If that cannot maintain the desired framerate, the user will be informed that they need to adjust their core settings.

This should help users who are experiencing some lag running PSX games. Instead of rendering all 60 frames, we can reactively render 40 or less to keep the number of processed frames at 60.

It seems like this scale is completely arbitrary. FCEUmm (NES) reports 5, Genesis GX Plus reports 7, Snes9x reports 12, mGBA doesn't report anything, and Beetle PSX reports 15.

The documentation doesn't really clear it up either:
>   Gives a hint to the frontend how demanding this implementation is on a system. E.g. reporting a level of 2 means this implementation should run decently on all frontends of level 2 and up.

Note that a better solution would be to support hardware rendering. The Beetle PSX HW core asks us if we support OpenGL_Core or Vulkan rendering and we say no to both.