### PR TITLE
Include boot executable filename in PSX hash

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1553,7 +1553,7 @@ void Application::loadState(const std::string& path)
   free(data);
   RA_OnLoadState(path.c_str());
 
-  updateCDMenu(NULL, 0, true);
+  updateCDMenu(NULL, 0, false);
 
   unsigned width, height, pitch;
   enum retro_pixel_format format;

--- a/src/CdRom.h
+++ b/src/CdRom.h
@@ -27,6 +27,7 @@ struct cdrom_t
   int sector_size;
   int sector_start;
   int sector_remaining;
+  int sector_header_size;
 };
 
 bool cdrom_open(cdrom_t& cdrom, const char* filename, int disc, int track);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -317,14 +317,13 @@ static bool romLoadNes(void* rom, size_t size)
 static bool romLoadPsx(Logger* logger, const std::string& path)
 {
   cdrom_t cdrom;
-  char buffer[2048], *tmp, *exe_name;
+  char buffer[2048], *tmp, *exe_name_start;
+  std::string exe_name;
   uint8_t* exe_raw;
   int size, remaining;
 
   if (!cdrom_open(cdrom, path.c_str(), 1, 1))
     return false;
-
-  exe_name = NULL;
 
   // extract the "BOOT=executable" line from the "SYSTEM.CNF" file, then hash the contents of "executable"
   if (!cdrom_seek_file(cdrom, "SYSTEM.CNF"))
@@ -338,19 +337,25 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
     {
       if (strncmp(tmp, "BOOT", 4) == 0)
       {
-        exe_name = tmp + 4;
-        while (isspace(*exe_name))
-          ++exe_name;
-        if (*exe_name == '=')
+        exe_name_start = tmp + 4;
+        while (isspace(*exe_name_start))
+          ++exe_name_start;
+        if (*exe_name_start == '=')
         {
-          ++exe_name;
-          while (isspace(*exe_name))
-            ++exe_name;
+          ++exe_name_start;
+          while (isspace(*exe_name_start))
+            ++exe_name_start;
 
-          if (strncmp(exe_name, "cdrom:", 6) == 0)
-            exe_name += 6;
-          if (*exe_name == '\\')
-            ++exe_name;
+          if (strncmp(exe_name_start, "cdrom:", 6) == 0)
+            exe_name_start += 6;
+          if (*exe_name_start == '\\')
+            ++exe_name_start;
+
+          tmp = exe_name_start;
+          while (*tmp != '\n' && *tmp != ';' && *tmp != ' ')
+            ++tmp;
+
+          exe_name.assign(exe_name_start, tmp - exe_name_start);
           break;
         }
       }
@@ -359,21 +364,15 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
         ++tmp;
     }
 
-    if (!exe_name)
+    if (exe_name.empty())
     {
       logger->debug(TAG "Failed to locate BOOT directive in SYSTEM.CNF in %s", path.c_str());
     }
     else
     {
-      tmp = exe_name;
-      while (*tmp != '\n' && *tmp != ';' && *tmp != ' ')
-        ++tmp;
-      strncpy(buffer, exe_name, tmp - exe_name);
-      buffer[tmp - exe_name] = '\0';
-
-      if (!cdrom_seek_file(cdrom, buffer))
+      if (!cdrom_seek_file(cdrom, exe_name.c_str()))
       {
-        logger->debug(TAG "Failed to locate %s in %s", buffer, path.c_str());
+        logger->debug(TAG "Failed to locate %s in %s", exe_name.c_str(), path.c_str());
       }
       else
       {
@@ -381,9 +380,18 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
 
         // the PSX-E header specifies the executable size as a 4-byte value 28 bytes into the header, which doesn't
         // include the header itself. We want to include the header in the hash, so append another 2048 to that value.
-        remaining = size = (((uint8_t)buffer[31] << 24) | ((uint8_t)buffer[30] << 16) | ((uint8_t)buffer[29] << 8) | (uint8_t)buffer[28]) + 2048;
+        size = (((uint8_t)buffer[31] << 24) | ((uint8_t)buffer[30] << 16) | ((uint8_t)buffer[29] << 8) | (uint8_t)buffer[28]) + 2048;
+
+        // there's also a few games that are use a singular engine and only differ via their data files. luckily, they have
+        // unique serial numbers, and use the serial number as the boot file in the standard way. include the boot file in the hash
+        size += exe_name.length();
+
         exe_raw = (uint8_t*)malloc(size);
         tmp = (char*)exe_raw;
+
+        memcpy(tmp, exe_name.c_str(), exe_name.length());
+        remaining = size - exe_name.length();
+        tmp += exe_name.length();
 
         do
         {
@@ -405,7 +413,7 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
 
   cdrom_close(cdrom);
 
-  return (exe_name != NULL);
+  return (!exe_name.empty());
 }
 
 static bool romLoadArcade(const std::string& path)


### PR DESCRIPTION
Changes the PSX hash from being the MD5 of the boot executable contents to being the MD5 of the concatenation of the boot executable name and it's contents.

Also includes support for CUE/BINs other than MODE2/2352