### PR TITLE
support BOOT executables in subfolder

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -379,7 +379,7 @@ static bool romLoadPsx(Logger* logger, const std::string& path)
     {
       if (!cdrom_seek_file(cdrom, exe_name.c_str()))
       {
-        logger->debug(TAG "Failed to locate %s in %s", exe_name.c_str(), path.c_str());
+        logger->info(TAG "Failed to locate %s in %s", exe_name.c_str(), path.c_str());
       }
       else
       {


### PR DESCRIPTION
The "BOOT=" entry for Wild Arms is "EXE\SCUS_946.08", which requires navigating the directory tree.