### PR TITLE
include current core version information in User-Agent string

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -682,6 +682,20 @@ bool Application::loadCore(const std::string& coreName)
   }
 
   _coreName = coreName;
+
+  std::string coreDetail = coreName + "/";
+  const char* scan = _core.getSystemInfo()->library_version;
+  while (*scan)
+  {
+    if (*scan == ' ')
+      coreDetail.push_back('_');
+    else
+      coreDetail.push_back(*scan);
+
+    ++scan;
+  }
+  RA_SetUserAgentDetail(coreDetail.c_str());
+
   return true;
 }
 


### PR DESCRIPTION
Once a core is loaded, the RAIntegration User-Agent string is changed from
```RALibRetro/1.0.15.35 (WindowsNT 10.0) Integration/0.76.3.7```
to
```RALibRetro/1.0.15.35 (WindowsNT 10.0) Integration/0.76.3.7 mednafen_psx_libretro/0.9.44.1_3e3acfc```
or something similar