### PR TITLE
Allow more cores to be installed

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -4,6 +4,14 @@
     "extensions": "col",
     "systems": [44]
   },
+  "bsnes_mercury_balanced_libretro":{
+    "name": "bsnes-mercury (Balanced)",
+    "systems": [3]
+  },
+  "bsnes_mercury_performance_libretro":{
+    "name": "bsnes-mercury (Performance)",
+    "systems": [3]
+  },
   "fbalpha_libretro":{
     "name": "FB Alpha",
     "extensions": "zip",

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -41,6 +41,10 @@
     "name": "Mednafen NeoPop",
     "systems": [14]
   },
+  "mednafen_pce_fast_libretro":{
+    "name": "Beetle PCE Fast",
+    "systems": [8]
+  },
   "mednafen_psx_libretro":{
     "name": "Beetle PSX",
     "extensions": "m3u|cue",

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -93,5 +93,9 @@
   "stella_libretro":{
     "name": "Stella",
     "systems": [25]
+  },
+  "vba_next_libretro":{
+    "name": "VBA Next",
+    "systems": [5]
   }
 }

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -23,6 +23,16 @@
     "name": "Gambatte",
     "systems": [4,6]
   },
+  "gearsystem_libretro":{
+    "name": "Gearsystem",
+    "extensions": "bin|sms|rom",
+    "systems": [1,11]
+  },
+  "gearsystem_libretro":{
+    "name": "Gearsystem",
+    "extensions": "gg|sg",
+    "systems": [15]
+  },
   "genesis_plus_gx_libretro":{
     "name": "Genesis Plus GX",
     "extensions": "bin|gen|smd|md|sms",

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -1,4 +1,9 @@
 {
+  "bluemsx_libretro":{
+    "name": "blueMSX",
+    "extensions": "col",
+    "systems": [44]
+  },
   "fbalpha_libretro":{
     "name": "FB Alpha",
     "extensions": "zip",

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -23,6 +23,10 @@
     "name": "Gambatte",
     "systems": [4,6]
   },
+  "gearboy_libretro":{
+    "name": "Gearboy",
+    "systems": [4,6]
+  },
   "gearsystem_libretro":{
     "name": "Gearsystem",
     "extensions": "bin|sms|rom",

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -4,6 +4,11 @@
     "extensions": "col",
     "systems": [44]
   },
+  "bluemsx_libretro":{
+    "name": "blueMSX",
+    "extensions": "sg",
+    "systems": [33]
+  },
   "bsnes_mercury_balanced_libretro":{
     "name": "bsnes-mercury (Balanced)",
     "systems": [3]

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -47,6 +47,10 @@
     "name": "Handy",
     "systems": [13]
   },
+  "mednafen_gba_libretro":{
+    "name": "Mednafen VBA-M",
+    "systems": [5]
+  },
   "mednafen_ngp_libretro":{
     "name": "Mednafen NeoPop",
     "systems": [14]

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -270,17 +270,19 @@ const char* getSystemName(System system)
   case System::kMasterSystem:   return "Master System";
   case System::kMegaDrive:      return "Sega Genesis";
   case System::kNintendo:       return "Nintendo Entertainment System";
-  case System::kPCEngine:       return "TurboGrafx-16";
+  case System::kPCEngine:       return "PC Engine";
   case System::kSuperNintendo:  return "Super Nintendo Entertainment System";
   case System::kGameBoy:        return "Game Boy";
   case System::kGameBoyColor:   return "Game Boy Color";
   case System::kGameBoyAdvance: return "Game Boy Advance";
+  case System::kNintendo64:     return "Nintendo 64";
   case System::kPlayStation1:   return "PlayStation";
   case System::kNeoGeoPocket:   return "Neo Geo Pocket";
   case System::kVirtualBoy:     return "Virtual Boy";
   case System::kGameGear:       return "Game Gear";
   case System::kArcade:         return "Arcade";
   case System::kAtari7800:      return "Atari 7800";
+  case System::kColecovision:   return "Colecovision";
   default:                      break;
   }
   

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -283,6 +283,7 @@ const char* getSystemName(System system)
   case System::kArcade:         return "Arcade";
   case System::kAtari7800:      return "Atari 7800";
   case System::kColecovision:   return "Colecovision";
+  case System::kSG1000:         return "SG-1000";
   default:                      break;
   }
   

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -48,7 +48,8 @@ enum class System
   kGameGear       = GameGear,
   kArcade         = Arcade,
   kAtari7800      = Atari7800,
-  kColecovision   = Colecovision
+  kColecovision   = Colecovision,
+  kSG1000         = SG1000
 };
 
 const std::string& getEmulatorName(const std::string& coreName, System system);

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -41,12 +41,14 @@ enum class System
   kGameBoy        = GB,
   kGameBoyColor   = GBC,
   kGameBoyAdvance = GBA,
+  kNintendo64     = N64,
   kPlayStation1   = PlayStation,
   kNeoGeoPocket   = NeoGeoPocket,
   kVirtualBoy     = VirtualBoy,
   kGameGear       = GameGear,
   kArcade         = Arcade,
-  kAtari7800      = Atari7800
+  kAtari7800      = Atari7800,
+  kColecovision   = Colecovision
 };
 
 const std::string& getEmulatorName(const std::string& coreName, System system);

--- a/src/libretro/BareCore.cpp
+++ b/src/libretro/BareCore.cpp
@@ -151,7 +151,8 @@ void libretro::BareCore::init() const
 void libretro::BareCore::deinit() const
 {
   _logger->debug(TAG "Calling %s", __FUNCTION__);
-  _deinit();
+  if (_deinit)
+    _deinit();
   _logger->debug(TAG "Called  %s", __FUNCTION__);
 }
 

--- a/src/libretro/BareCore.cpp
+++ b/src/libretro/BareCore.cpp
@@ -52,7 +52,8 @@ bool libretro::BareCore::load(libretro::LoggerComponent* logger, const char* pat
   if (!_handle)
   {
     const std::wstring unicodePath = util::utf8ToUChar(path);
-    _handle = LoadLibraryW(unicodePath.c_str());
+    if (unicodePath.length() != strlen(path))
+      _handle = LoadLibraryW(unicodePath.c_str());
   }
 
   if (_handle == NULL)


### PR DESCRIPTION
Adds support for:
* blueMSX (#93) - Colecovision, SG-1000
* Beetle GBA (#85) - GBA
* Beetle PCE (#90) - PCEngine / TurboGrafx-16
* bsnes-mercury (#81) - SNES
* Gearboy (#82) - GB, GBC
* Gearsystem (#88) - Genesis, Master System, Game Gear
  - Note that this core does not support .md files, so I'm not positive that the Genesis functionality is correct, but since it does work with GameGear, I'm giving it the benefit of the doubt
* VBA Next (#84) - GBA
