### PR TITLE
add support for Saturn via Beetle Saturn

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -86,6 +86,11 @@
     "extensions": "m3u|cue",
     "systems": [12]
   },
+  "mednafen_saturn_libretro":{
+    "name": "Beetle Saturn",
+    "extensions": "m3u|cue",
+    "systems": [39]
+  },
   "mednafen_supergrafx_libretro":{
     "name": "Mednafen SuperGrafX",
     "systems": [8]

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -274,6 +274,7 @@ const char* getSystemName(System system)
   case System::kMegaDrive:      return "Sega Genesis";
   case System::kSegaCD:         return "Sega CD";
   case System::kSega32X:        return "Sega 32X";
+  case System::kSaturn:         return "Sega Saturn";
   case System::kNintendo:       return "Nintendo Entertainment System";
   case System::kPCEngine:       return "PC Engine";
   case System::kSuperNintendo:  return "Super Nintendo Entertainment System";
@@ -509,6 +510,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
     break;
 
   case System::kSegaCD:
+  case System::kSaturn:
     ok = romLoadSegaCd(logger, path);
     break;
 

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -37,6 +37,7 @@ enum class System
   kMegaDrive      = MegaDrive,
   kSegaCD         = SegaCD,
   kSega32X        = Sega32X,
+  kSaturn         = Saturn,
   kNintendo       = NES,
   kPCEngine       = PCEngine,
   kSuperNintendo  = SNES,


### PR DESCRIPTION
Implements #114 

The only limitation seems to be that the core doesn't support cue files that reference MP3 audio tracks.

Hashing is done using the same logic as Sega CD. Note that the Sega CD header is 512 bytes, whereas the Saturn header is only 256, but is followed by several KB of executable code, so hashing 512 bytes instead of just 256 will still result in a unique hash. This is an optimization for RetroArch where the hash is calculated without knowing which system it's trying to hash. By using the same hashing algorithm, RetroArch will have one less hash to check.