### PR TITLE
update PCEngine-CD hash algorithm

### DIFF
--- a/src/CdRom.cpp
+++ b/src/CdRom.cpp
@@ -110,6 +110,7 @@ static bool cdrom_open_cue(cdrom_t& cdrom, const char* filename, int track, Logg
   FILE* fp;
   char buffer[1024], *file = buffer, *ptr, *ptr2, *mode = buffer;
   int current_track = 0;
+  size_t num_read = 0;
 
   memset(&cdrom, 0, sizeof(cdrom_t));
 
@@ -117,7 +118,8 @@ static bool cdrom_open_cue(cdrom_t& cdrom, const char* filename, int track, Logg
   if (!fp)
     return false;
 
-  fread(buffer, 1, sizeof(buffer), fp);
+  num_read = fread(buffer, 1, sizeof(buffer), fp);
+  buffer[num_read] = 0;
   fclose(fp);
 
   for (ptr = buffer; *ptr; ++ptr)

--- a/src/CdRom.cpp
+++ b/src/CdRom.cpp
@@ -118,7 +118,7 @@ static bool cdrom_open_cue(cdrom_t& cdrom, const char* filename, int track, Logg
   if (!fp)
     return false;
 
-  num_read = fread(buffer, 1, sizeof(buffer), fp);
+  num_read = fread(buffer, 1, sizeof(buffer) - 1, fp);
   buffer[num_read] = 0;
   fclose(fp);
 

--- a/src/CdRom.h
+++ b/src/CdRom.h
@@ -30,6 +30,7 @@ struct cdrom_t
   int sector_start;
   int sector_remaining;
   int sector_header_size;
+  int pregap_sectors;
 };
 
 bool cdrom_open(cdrom_t& cdrom, const char* filename, int disc, int track, Logger* logger);


### PR DESCRIPTION
The previous algorithm was to hash the cue file, which required having a specific exact cue file (same filenames, casing, whitespace). This methodology is very error prone.

The new algorithm is similar to the PSX hashing algorithm. A descriptive name is extracted from the disc header, then the boot code is appended to the descriptive name, and the whole thing is hashed. Unlike PSX, the PCE-CD format predates ISO-9660, so there isn't a file system. Instead, the boot code is located by reading data in the disc header.

Additionally, from the CDs that I examined, many of them have smaller than expected boot code blocks, suggesting that the boot code loads and launches additional code. Even with the smaller code blocks, I haven't yet experienced any unexpected collisions. All unique games remain unique, but regional variants (US vs JP) and re-released versions did result in matching hashes. If this becomes an issue in the future, we can revisit.