### PR TITLE
add support for Atari Jaguar

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -129,5 +129,9 @@
   "vba_next_libretro":{
     "name": "VBA Next",
     "systems": [5]
+  },
+  "virtualjaguar_libretro":{
+    "name": "Virtual Jaguar",
+    "systems": [17]
   }
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -270,6 +270,7 @@ const char* getSystemName(System system)
   {
   case System::kAtari2600:      return "Atari 2600";
   case System::kAtariLynx:      return "Atari Lynx";
+  case System::kAtariJaguar:    return "Atari Jaguar";
   case System::kMasterSystem:   return "Master System";
   case System::kMegaDrive:      return "Sega Genesis";
   case System::kSegaCD:         return "Sega CD";
@@ -466,6 +467,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
   {
   case System::kAtari2600:
   case System::kAtari7800:
+  case System::kAtariJaguar:
   case System::kColecovision:
   case System::kPCEngine:
   case System::kGameBoy:

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -33,6 +33,7 @@ enum class System
   kNone           = UnknownConsoleID,
   kAtari2600      = Atari2600,
   kAtariLynx      = Lynx,
+  kAtariJaguar    = Jaguar,
   kMasterSystem   = MasterSystem,
   kMegaDrive      = MegaDrive,
   kSegaCD         = SegaCD,


### PR DESCRIPTION
Just core enablement. Hashing is entire file. 2MB of system RAM is exposed. 