### PR TITLE
always use frame smoothing; attempt to disable vsync before stopping emulator

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -91,6 +91,7 @@ protected:
   // Helpers
   void        processEvents();
   void        runSmoothed();
+  void        runTurbo();
 
   void        loadGame();
   void        enableItems(const UINT* items, size_t count, UINT enable);


### PR DESCRIPTION
Calls the frame smoothing code for all systems, regardless of how demanding the core claims the system is. 

If the target framerate cannot be achieved, vsync will be disabled. This is important for systems where the target framerate is higher than the monitor refresh rate (WonderSwan runs at 75Hz, most monitors are 60Hz). If the target framerate still cannot be achieved, the existing "emulator disabled" warning will be displayed. 

vsync is re-enabled whenever a game is loaded, and the process restarts.