### PR TITLE
add support for pokemini core

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -114,6 +114,10 @@
     "extensions": "bin",
     "systems": [10]
   },
+  "pokemini_libretro":{
+    "name": "PokeMini",
+    "systems": [24]
+  },
   "prosystem_libretro":{
     "name": "ProSystem",
     "systems": [51]

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -286,6 +286,7 @@ const char* getSystemName(System system)
   case System::kGameGear:       return "Game Gear";
   case System::kArcade:         return "Arcade";
   case System::kAtari7800:      return "Atari 7800";
+  case System::kPokemonMini:    return "Pokemon Mini";
   case System::kColecovision:   return "Colecovision";
   case System::kSG1000:         return "SG-1000";
   default:                      break;

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -48,6 +48,7 @@ enum class System
   kGameGear       = GameGear,
   kArcade         = Arcade,
   kAtari7800      = Atari7800,
+  kPokemonMini    = PokemonMini,
   kColecovision   = Colecovision,
   kSG1000         = SG1000
 };

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -251,6 +251,7 @@ bool romLoaded(Logger* logger, System system, const std::string& path, void* rom
     case System::kAtari7800:
     case System::kAtariJaguar:
     case System::kColecovision:
+    case System::kPokemonMini:
     case System::kGameBoy:
     case System::kGameBoyColor:
     case System::kGameBoyAdvance:


### PR DESCRIPTION
From several conversations in discord, apparently this core is fully functional. Hashing is full ROM.

System runs at 72Hz, so it is dependent on the new frame smoothing algorithm to achieve accurate framerates on 60Hz monitors.