### PR TITLE
add screen rotation to video settings

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -65,6 +65,8 @@ public:
   bool isGameActive();
   const std::string& gameName() const { return _gameFileName; }
 
+  void onRotationChanged(Video::Rotation oldRotation, Video::Rotation newRotation);
+
 protected:
   struct MemoryRegion
   {

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -57,6 +57,12 @@ public:
   unsigned getViewWidth() const { return _viewWidth; }
   unsigned getViewHeight() const { return _viewHeight; }
 
+  void setRotation(Rotation rotation) override;
+  Rotation getRotation() const override { return _rotation; }
+
+  typedef void (*RotationHandler)(Rotation oldRotation, Rotation newRotation);
+  void setRotationChangedHandler(RotationHandler handler) { _rotationHandler = handler; }
+
 protected:
   GLuint createProgram(GLint* pos, GLint* uv, GLint* tex);
   GLuint createVertexBuffer(unsigned windowWidth, unsigned windowHeight, float texScaleX, float texScaleY, GLint pos, GLint uv);
@@ -80,6 +86,8 @@ protected:
   unsigned                _viewHeight;
   enum retro_pixel_format _pixelFormat;
   float                   _aspect;
+  Rotation                _rotation;
+  RotationHandler         _rotationHandler;
 
   bool                    _preserveAspect;
   bool                    _linearFilter;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -131,6 +131,18 @@ namespace libretro
     virtual retro_proc_address_t getProcAddress(const char* symbol) = 0;
 
     virtual void showMessage(const char* msg, unsigned frames) = 0;
+
+    /* NOTE: these are counter-clockwise rotations per libretro.h */
+    enum class Rotation
+    {
+      None = 0,
+      Ninety = 1,
+      OneEighty = 2,
+      TwoSeventy = 3
+    };
+
+    virtual void setRotation(Rotation rotation) = 0;
+    virtual Rotation getRotation() const = 0;
   };
 
   /**

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -148,6 +148,16 @@ namespace
       (void)msg;
       (void)frames;
     }
+
+    virtual void setRotation(Rotation rotation) override
+    {
+      (void)rotation;
+    }
+
+    Rotation getRotation() const override
+    {
+      return Rotation::None;
+    }
   };
 
   class Audio: public libretro::AudioComponent
@@ -520,7 +530,6 @@ void libretro::Core::reset()
   _performanceLevel = 0;
   _pixelFormat = RETRO_PIXEL_FORMAT_UNKNOWN;
   _supportsNoGame = false;
-  _rotation = 0;
   _supportAchievements = false;
   _inputDescriptorsCount = 0;
   _inputDescriptors = NULL;
@@ -560,7 +569,7 @@ char* libretro::Core::strdup(const char* str)
 
 bool libretro::Core::setRotation(unsigned data)
 {
-  _rotation = data;
+  _video->setRotation((Video::Rotation)data);
   return true;
 }
 

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -58,7 +58,6 @@ namespace libretro
     inline enum retro_pixel_format getPixelFormat()         const { return _pixelFormat; }
     inline bool                    getNeedsHardwareRender() const { return _needsHardwareRender; }
     inline bool                    getSupportsNoGame()      const { return _supportsNoGame; }
-    inline unsigned                getRotation()            const { return _rotation; }
     inline bool                    getSupportAchievements() const { return _supportAchievements; }
     inline void                    unloadGame()                   { _core.unloadGame(); }
 
@@ -210,7 +209,6 @@ namespace libretro
     unsigned                        _performanceLevel;
     enum retro_pixel_format         _pixelFormat;
     bool                            _supportsNoGame;
-    unsigned                        _rotation;
     bool                            _supportAchievements;
     
     unsigned                        _inputDescriptorsCount;


### PR DESCRIPTION
implements #48 - adds a Rotation option to the Video Settings dialog:

![image](https://user-images.githubusercontent.com/32680403/69481377-1251db80-0dce-11ea-856c-6f1af72f5520.png)

![image](https://user-images.githubusercontent.com/32680403/69481375-0d8d2780-0dce-11ea-9295-71d0327c6757.png)

also handles #131 - if the core suggests a rotation for a game, it's automatically applied.

![image](https://user-images.githubusercontent.com/32680403/69481389-32819a80-0dce-11ea-904c-d07b7d253616.png)