### PR TITLE
Updated NDS hashing algorithm

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -17,6 +17,10 @@
     "name": "bsnes-mercury (Performance)",
     "systems": [3]
   },
+  "desmume_libretro":{
+    "name": "DeSmuME",
+    "systems": [18]
+  },
   "fbalpha_libretro":{
     "name": "FB Alpha",
     "extensions": "zip",

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1077,17 +1077,26 @@ bool Application::loadGame(const std::string& path)
 
   if (issupportedzip)
   {
+    /* user is loading a zip file, and the core supports it */
     size = 0;
     data = NULL;
   }
-  else 
+  else if (info->need_fullpath)
+  {
+    /* core wants the full path, don't load the data unless we need it to hash */
+    size = 0;
+    data = NULL;
+  }
+  else
   {
     if (iszip)
     {
+      /* core doesn't support zip files, unzip it into a buffer */
       data = util::loadZippedFile(&_logger, path, &size, unzippedFileName);
     }
     else
     {
+      /* load the file into a buffer so we can hash it */
       data = util::loadFile(&_logger, path, &size);
     }
 
@@ -1100,6 +1109,7 @@ bool Application::loadGame(const std::string& path)
 
   if (unzippedFileName.empty())
   {
+    /* did not extract a file from an archive, just use the original file name */
     unzippedFileName = util::fileNameWithExtension(path);
   }
 

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -274,6 +274,7 @@ const char* getSystemName(System system)
   case System::kSega32X:        return "Sega 32X";
   case System::kSaturn:         return "Sega Saturn";
   case System::kNintendo:       return "Nintendo Entertainment System";
+  case System::kNintendoDS:     return "Nintendo DS";
   case System::kPCEngine:       return "PC Engine";
   case System::kSuperNintendo:  return "Super Nintendo Entertainment System";
   case System::kGameBoy:        return "Game Boy";

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -36,6 +36,7 @@ enum class System
   kSega32X        = Sega32X,
   kSaturn         = Saturn,
   kNintendo       = NES,
+  kNintendoDS     = DS,
   kPCEngine       = PCEngine,
   kSuperNintendo  = SNES,
   kGameBoy        = GB,

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -91,14 +91,15 @@ static bool romLoadNintendoDS(Logger* logger, const std::string& path)
   else
   {
     BYTE* hash_buffer;
-    unsigned int hash_size, arm9_size, arm9_addr, arm7_size, arm7_addr;
+    unsigned int hash_size, arm9_size, arm9_addr, arm7_size, arm7_addr, icon_addr;
 
     arm9_addr = header[0x20] | (header[0x21] << 8) | (header[0x22] << 16) | (header[0x23] << 24);
     arm9_size = header[0x2C] | (header[0x2D] << 8) | (header[0x2E] << 16) | (header[0x2F] << 24);
     arm7_addr = header[0x30] | (header[0x31] << 8) | (header[0x32] << 16) | (header[0x33] << 24);
     arm7_size = header[0x3C] | (header[0x3D] << 8) | (header[0x3E] << 16) | (header[0x3F] << 24);
+    icon_addr = header[0x68] | (header[0x69] << 8) | (header[0x6A] << 16) | (header[0x6B] << 24);
 
-    hash_size = 0x160 + arm9_size + arm7_size;
+    hash_size = 0x160 + arm9_size + arm7_size + 0xA00;
     if (hash_size > 16 * 1024 * 1024)
     {
       logger->info(TAG "arm9 code size (%u) + arm7 code size (%u) exceeds 16MB", arm9_size, arm7_size);
@@ -119,6 +120,9 @@ static bool romLoadNintendoDS(Logger* logger, const std::string& path)
 
         fseek(file, arm7_addr, SEEK_SET);
         fread(&hash_buffer[0x160 + arm9_size], 1, arm7_size, file);
+
+        fseek(file, icon_addr, SEEK_SET);
+        fread(&hash_buffer[0x160 + arm9_size + arm7_size], 1, 0xA00, file);
 
         fclose(file);
 


### PR DESCRIPTION
An NDS ROM has a 0x160 byte header. In this header are pointers to icon/title information and to the boot code for both processors. The hash method that has been derived is to combine the header, the two pieces of boot code and the icon/title information and hash that. In most cases, this results in around 1MB of the file being hashed.

Additionally, support for SuperCard formatted ROMs was added. SuperCard ROMs have an additional 512 byte header prepended to the normal ROM. There isn't really any good documentation of the SuperCard header, so there's a small chance one might not be recognized. If that occurs, we can instruct the user to remove the 512 byte header and the normal ROM should be recognized. Note that DeSMuME does not currently support SuperCard formatted ROMs, so this feature won't get much use anyway.