### PR TITLE
better handling of gamepad reconnect

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -328,7 +328,7 @@ void Application::processEvents()
 
       case SDL_CONTROLLERDEVICEADDED:
       case SDL_CONTROLLERDEVICEREMOVED:
-        _input.processEvent(&event);
+        _input.processEvent(&event, &_keybinds);
         break;
 
       case SDL_CONTROLLERBUTTONUP:

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -469,11 +469,13 @@ KeyBinds::Action KeyBinds::translate(const SDL_KeyboardEvent* key, unsigned* ext
 
 KeyBinds::Action KeyBinds::translate(const SDL_ControllerButtonEvent* cbutton, unsigned* extra)
 {
+  SDL_JoystickID bindingID = getBindingID(cbutton->which);
+
   for (size_t i = 0; i < kMaxBindings; i++)
   {
     if (_bindings[i].type == Binding::Type::Button)
     {
-      if (cbutton->button == _bindings[i].button && cbutton->which == _bindings[i].joystick_id)
+      if (cbutton->button == _bindings[i].button && bindingID == _bindings[i].joystick_id)
       {
         if (cbutton->state == SDL_PRESSED)
           return translateButtonPress(i, extra);
@@ -487,6 +489,29 @@ KeyBinds::Action KeyBinds::translate(const SDL_ControllerButtonEvent* cbutton, u
   }
 
   return Action::kNothing;
+}
+
+void KeyBinds::mapDevice(SDL_JoystickID originalID, SDL_JoystickID newID)
+{
+  for (auto pair = _bindingMap.begin(); pair != _bindingMap.end(); ++pair)
+  {
+    if (pair->second == originalID)
+    {
+      _bindingMap.erase(pair);
+      break;
+    }
+  }
+
+  _bindingMap.insert(std::make_pair(newID, originalID));
+}
+
+SDL_JoystickID KeyBinds::getBindingID(SDL_JoystickID id) const
+{
+  auto iter = _bindingMap.find(id);
+  if (iter != _bindingMap.end())
+    return iter->second;
+
+  return id;
 }
 
 static bool IsAnalog(int button)
@@ -511,6 +536,7 @@ static bool IsAnalog(int button)
 void KeyBinds::translate(const SDL_ControllerAxisEvent* caxis, Input& input,
   Action* action1, unsigned* extra1, Action* action2, unsigned* extra2)
 {
+  SDL_JoystickID bindingID = getBindingID(caxis->which);
   *action1 = *action2 = Action::kNothing;
 
   int threshold = static_cast<int>(32767 * input.getJoystickSensitivity(caxis->which));
@@ -519,7 +545,7 @@ void KeyBinds::translate(const SDL_ControllerAxisEvent* caxis, Input& input,
   {
     if (_bindings[i].type == Binding::Type::Axis)
     {
-      if (caxis->axis == _bindings[i].button && caxis->which == _bindings[i].joystick_id)
+      if (caxis->axis == _bindings[i].button && bindingID == _bindings[i].joystick_id)
       {
         if (IsAnalog(i))
         {
@@ -869,6 +895,7 @@ public:
   const KeyBinds::Binding getButtonDescriptor() const { return _buttonDescriptor; }
 
   Input* _input = nullptr;
+  std::map<SDL_JoystickID, SDL_JoystickID>* _bindingMap = nullptr;
   bool _isOpen = false;
   bool _isAnalog = false;
 
@@ -1027,6 +1054,11 @@ protected:
               break;
 
             _buttonDescriptor = button;
+
+            auto pair = _bindingMap->find(button.joystick_id);
+            if (pair != _bindingMap->end())
+              _buttonDescriptor.joystick_id = pair->second;
+
             char buffer[32];
             KeyBinds::getBindingString(buffer, _buttonDescriptor);
             SetDlgItemText(hwnd, ID_LABEL, buffer);
@@ -1124,6 +1156,7 @@ public:
   }
 
   Input* _input = nullptr;
+  std::map<SDL_JoystickID, SDL_JoystickID>* _bindingMap = nullptr;
 
   const KeyBinds::BindingList& getBindings() const { return _bindings; }
 
@@ -1184,6 +1217,7 @@ protected:
     ChangeInputDialog db;
     db.init(buffer);
     db._input = _input;
+    db._bindingMap = _bindingMap;
     db._isAnalog = IsAnalog(button);
 
     GetDlgItemText(hwnd, 10000 + button, buffer, sizeof(buffer));
@@ -1216,6 +1250,7 @@ void KeyBinds::showControllerDialog(Input& input, int port)
   InputDialog db;
   db.init(label);
   db._input = &input;
+  db._bindingMap = &_bindingMap;
 
   switch (port)
   {
@@ -1236,6 +1271,8 @@ void KeyBinds::showHotKeyDialog(Input& input)
   InputDialog db;
   db.init("Hot Keys");
   db._input = &input;
+  db._bindingMap = &_bindingMap;
+
   db.initHotKeyButtons(_bindings);
 
   if (db.show())

--- a/src/KeyBinds.h
+++ b/src/KeyBinds.h
@@ -24,6 +24,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include <SDL_events.h>
 
 #include <array>
+#include <map>
 
 class Input; // forward reference
 
@@ -87,6 +88,8 @@ public:
   void translate(const SDL_ControllerAxisEvent* caxis, Input& input,
     Action* action1, unsigned* extra1, Action* action2, unsigned* extra2);
 
+  void mapDevice(SDL_JoystickID originalID, SDL_JoystickID newID);
+
   void showControllerDialog(Input& input, int portId);
   void showHotKeyDialog(Input& input);
 
@@ -120,6 +123,9 @@ protected:
   KeyBinds::Action translateAnalog(int button, Sint16 value, unsigned* extra);
 
   BindingList _bindings;
+  SDL_JoystickID getBindingID(SDL_JoystickID id) const;
+
+  std::map<SDL_JoystickID, SDL_JoystickID> _bindingMap;
 
   unsigned _slot;
   bool _ff;

--- a/src/components/Input.h
+++ b/src/components/Input.h
@@ -71,11 +71,10 @@ public:
   void destroy() {}
   void reset();
 
-  void addController(int which);
   void autoAssign();
   void buttonEvent(int port, Button button, bool pressed);
   void axisEvent(int port, Axis axis, int16_t value);
-  void processEvent(const SDL_Event* event);
+  void processEvent(const SDL_Event* event, KeyBinds* keyBinds);
   void mouseButtonEvent(MouseButton button, bool pressed);
   void mouseMoveEvent(int relative_x, int relative_y, int absolute_x, int absolute_y);
 
@@ -139,7 +138,8 @@ protected:
     kMaxPorts = 8
   };
 
-  void addController(const SDL_Event* event);
+  SDL_JoystickID addController(int which);
+  void addController(const SDL_Event* event, KeyBinds* keyBinds);
   void removeController(const SDL_Event* event);
 
   static const char* s_getType(int index, void* udata);
@@ -151,6 +151,8 @@ protected:
 
   std::map<SDL_JoystickID, Pad> _pads;
   std::vector<Descriptor>       _descriptors;
+
+  std::map<SDL_JoystickID, SDL_JoystickGUID> _joystickGUIDs;
 
   uint64_t                    _ports;
   std::vector<ControllerInfo> _info[kMaxPorts];


### PR DESCRIPTION
Every time the controller reconnects, SDL assigns it a new ID. Because the key binds are looking for a specific ID in case the user has multiple controllers, this breaks the bindings and the controller no longer appears to function. It does function, but needs to be rebound. This is not a pleasant (or obvious) user experience.

I've modified the logic that detects the reconnected controller to map the controller's GUID to the old ID and tell the binding code that the new ID maps to the old ID so the bindings will continue to work.