### PR TITLE
add melonDS core

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -107,6 +107,10 @@
     "name": "Mednafen WonderSwan",
     "systems": [53]
   },
+  "melonds_libretro":{
+    "name": "melonDS",
+    "systems": [18]
+  },
   "mgba_libretro":{
     "name": "mGBA",
     "extensions": "gba",

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1154,6 +1154,10 @@ bool Application::loadGame(const std::string& path)
       free(data);
     }
 
+    // A failure in loadGame typically destroys the core.
+    if (_core.getSystemInfo()->library_name == NULL)
+      _fsm.unloadCore();
+
     return false;
   }
 


### PR DESCRIPTION
seems to expose the memory correctly, but doesn't function as well as desmume in demanding 3D scenes. including it as an alternative primarily for debugging.