### PR TITLE
seprate initCore from loadCore so configs are available in initCore

### DIFF
--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -283,7 +283,7 @@ bool libretro::Core::loadCore(const char* core_path)
     return false;
   }
 
-  return initCore();
+  return true;
 }
 
 bool libretro::Core::loadGame(const char* game_path, void* data, size_t size)

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -39,6 +39,7 @@ namespace libretro
   public:
     bool init(const Components* components);
     bool loadCore(const char* core_path);
+    bool initCore();
     bool loadGame(const char* game_path, void* data, size_t size);
 
     void destroy();
@@ -113,7 +114,6 @@ namespace libretro
     
   protected:
     // Initialization
-    bool initCore();
     bool initAV();
     void reset();
     


### PR DESCRIPTION
fixes issue where DeSmuMe core was not honoring "Firmware Language" setting