### PR TITLE
ensure controller variables exist for config dialog

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -950,8 +950,6 @@ bool Application::loadCore(const std::string& coreName)
     });
 
     free(data);
-
-    _config.initializeInput(_input);
   }
 
   // tell the core to startup (must be done after reading configs)

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -51,7 +51,6 @@ public:
 
   std::string serialize();
   void deserialize(const char* json);
-  void initializeInput(Input& input);
 
   void showDialog(const std::string& coreName, Input& input);
 


### PR DESCRIPTION
Fixes #158 

I suspect this was broken by #148, but I'm not 100% certain on that. By changing the timing of when the config is loaded, the input structures may not have been initialized, leading to the variables for the controllers not being defined.

I've moved the logic that defines the variables for the controllers into the code that shows the dialog. Additionally, I've updated the code to display the core-specific controller name instead of RetroPad when the core provides a specific label.

I've also updated the code to allow hot-swapping controllers (changing the value without resetting the emulator).