### PR TITLE
Add 7z to FBNeo supported extensions

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -29,7 +29,6 @@
   },
   "fbneo_libretro":{
     "name": "FinalBurn Neo",
-    "extensions": "zip|7z",
     "systems": [27]
   },
   "fceumm_libretro":{

--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -29,7 +29,7 @@
   },
   "fbneo_libretro":{
     "name": "FinalBurn Neo",
-    "extensions": "zip",
+    "extensions": "zip|7z",
     "systems": [27]
   },
   "fceumm_libretro":{


### PR DESCRIPTION
FBNeo supports 7z internally. I've tested to verify they load correctly.