### PR TITLE
support RETRO_ENVIRONMENT_GET_INPUT_BITMASKS

### DIFF
--- a/src/components/Input.cpp
+++ b/src/components/Input.cpp
@@ -81,12 +81,12 @@ void Input::reset()
   ControllerInfo none;
   none._description = "None";
   none._id = RETRO_DEVICE_NONE;
-  memset(none._state, 0, sizeof(none._state));
+  none._state = 0;
 
   ControllerInfo retropad;
   retropad._description = "RetroPad";
   retropad._id = RETRO_DEVICE_JOYPAD;
-  memset(retropad._state, 0, sizeof(retropad._state));
+  retropad._state = 0;
 
   for (unsigned i = 0; i < kMaxPorts; i++)
   {
@@ -243,7 +243,10 @@ void Input::buttonEvent(int port, Button button, bool pressed)
     default:              return;
   }
 
-  _info[port][_devices[port]]._state[rbutton] = pressed;
+  if (pressed)
+    _info[port][_devices[port]]._state |= (1 << rbutton);
+  else
+    _info[port][_devices[port]]._state &= ~(1 << rbutton);
 }
 
 void Input::axisEvent(int port, Axis axis, int16_t value)
@@ -334,12 +337,12 @@ void Input::setControllerInfo(const struct retro_controller_info* rinfo, unsigne
   ControllerInfo none;
   none._description = "None";
   none._id = RETRO_DEVICE_NONE;
-  memset(none._state, 0, sizeof(none._state));
+  none._state = 0;
 
   ControllerInfo retropad;
   retropad._description = "RetroPad";
   retropad._id = RETRO_DEVICE_JOYPAD;
-  memset(retropad._state, 0, sizeof(retropad._state));
+  retropad._state = 0;
 
   _ports = 0;
 
@@ -366,7 +369,7 @@ void Input::setControllerInfo(const struct retro_controller_info* rinfo, unsigne
         if ((info._id & RETRO_DEVICE_MASK) == RETRO_DEVICE_JOYPAD ||
           (info._id & RETRO_DEVICE_MASK) == RETRO_DEVICE_ANALOG)
         {
-          memset(info._state, 0, sizeof(info._state));
+          info._state = 0;
           memset(info._axis, 0, sizeof(info._axis));
 
           _info[port].push_back(info);
@@ -433,7 +436,10 @@ int16_t Input::read(unsigned port, unsigned device, unsigned index, unsigned id)
     switch (device)
     {
       case RETRO_DEVICE_JOYPAD:
-        return _info[port][_devices[port]]._state[id] ? 32767 : 0;
+        if (id == RETRO_DEVICE_ID_JOYPAD_MASK)
+          return _info[port][_devices[port]]._state;
+
+        return (_info[port][_devices[port]]._state >> id) & 1;
 
       case RETRO_DEVICE_ANALOG:
         return _info[port][_devices[port]]._axis[index << 1 | id];

--- a/src/components/Input.h
+++ b/src/components/Input.h
@@ -122,7 +122,7 @@ protected:
   {
     std::string _description;
     unsigned    _id;
-    bool        _state[16];
+    int16_t     _state;
     int16_t     _axis[4];
   };
 

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -1252,6 +1252,15 @@ bool libretro::Core::setSupportAchievements(bool data)
   return true;
 }
 
+bool libretro::Core::getInputBitmasks(bool* data)
+{
+  // The documentation says the parameter is a [bool * that indicates whether or not the
+  // frontend supports input bitmasks being returned by retro_input_state_t], but in
+  // practice, the parameter is ignored and the core just looks at the return value.
+  (void)data;
+  return true;
+}
+
 static void getEnvName(char* name, size_t size, unsigned cmd)
 {
   static const char* names[] =
@@ -1266,7 +1275,7 @@ static void getEnvName(char* name, size_t size, unsigned cmd)
     "SHUTDOWN",
     "SET_PERFORMANCE_LEVEL",
     "GET_SYSTEM_DIRECTORY",
-    "SET_PIXEL_FORMAT",
+    "SET_PIXEL_FORMAT",                        // 10
     "SET_INPUT_DESCRIPTORS",
     "SET_KEYBOARD_CALLBACK",
     "SET_DISK_CONTROL_INTERFACE",
@@ -1276,7 +1285,7 @@ static void getEnvName(char* name, size_t size, unsigned cmd)
     "GET_VARIABLE_UPDATE",
     "SET_SUPPORT_NO_GAME",
     "GET_LIBRETRO_PATH",
-    "20",
+    "20",                                      // 20
     "SET_FRAME_TIME_CALLBACK",
     "SET_AUDIO_CALLBACK",
     "GET_RUMBLE_INTERFACE",
@@ -1286,7 +1295,7 @@ static void getEnvName(char* name, size_t size, unsigned cmd)
     "GET_LOG_INTERFACE",
     "GET_PERF_INTERFACE",
     "GET_LOCATION_INTERFACE",
-    "GET_CORE_ASSETS_DIRECTORY",
+    "GET_CORE_ASSETS_DIRECTORY",               // 30
     "GET_SAVE_DIRECTORY",
     "SET_SYSTEM_AV_INFO",
     "SET_PROC_ADDRESS_CALLBACK",
@@ -1296,14 +1305,25 @@ static void getEnvName(char* name, size_t size, unsigned cmd)
     "SET_GEOMETRY",
     "GET_USERNAME",
     "GET_LANGUAGE",
-    "GET_CURRENT_SOFTWARE_FRAMEBUFFER",
+    "GET_CURRENT_SOFTWARE_FRAMEBUFFER",        // 40
     "GET_HW_RENDER_INTERFACE",
     "SET_SUPPORT_ACHIEVEMENTS",
     "SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE",
     "SET_SERIALIZATION_QUIRKS",
     "GET_VFS_INTERFACE",
     "GET_LED_INTERFACE",
-    "GET_AUDIO_VIDEO_ENABLE"
+    "GET_AUDIO_VIDEO_ENABLE",
+    "GET_MIDI_INTERFACE",
+    "GET_FASTFORWARDING",
+    "GET_TARGET_REFRESH_RATE",                 // 50
+    "GET_INPUT_BITMASKS",
+    "GET_CORE_OPTIONS_VERSION",
+    "SET_CORE_OPTIONS",
+    "SET_CORE_OPTIONS_INTL",
+    "SET_CORE_OPTIONS_DISPLAY",
+    "GET_PREFERRED_HW_RENDER",
+    "GET_DISK_CONTROL_INTERFACE_VERSION",
+    "SET_DISK_CONTROL_EXT_INTERFACE",
   };
 
   cmd &= ~(RETRO_ENVIRONMENT_EXPERIMENTAL | RETRO_ENVIRONMENT_PRIVATE);
@@ -1484,12 +1504,16 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
     ret = setSupportAchievements(*(bool*)data);
     break;
 
+  case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+    ret = getInputBitmasks((bool*)data);
+    break;
+
   default:
     cmd &= ~(RETRO_ENVIRONMENT_EXPERIMENTAL | RETRO_ENVIRONMENT_PRIVATE);
 
     if ((_calls[cmd / 8] & (1 << (cmd & 7))) == 0)
     {
-      _logger->error(TAG "Unimplemented env call: %s (%u)", name, cmd);
+      _logger->error(TAG "Unimplemented env call: %s", name, cmd);
       _calls[cmd / 8] |= 1 << (cmd & 7);
     }
 

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -169,6 +169,7 @@ namespace libretro
     bool getCurrentSoftwareFramebuffer(struct retro_framebuffer* data) const;
     bool getHWRenderInterface(const struct retro_hw_render_interface** data) const;
     bool setSupportAchievements(bool data);
+    bool getInputBitmasks(bool* data);
 
     // Callbacks
     bool                 environmentCallback(unsigned cmd, void* data);


### PR DESCRIPTION
allows the core to get the entire joypad state in a single call instead of polling for each button individually.

also updates the `RETRO_ENVIRONMENT_` enum string map for the new enum entries.