### PR TITLE
handle audio devices with more than 2 output channels

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -218,6 +218,9 @@ bool Application::init(const char* title, int width, int height)
     goto error;
   }
 
+  _logger.info(TAG "Initialized audio device. %d channels@%dHz (format:%04X, silence:%d, samples:%d, padding:%d, size:%d)",
+    _audioSpec.channels, _audioSpec.freq, _audioSpec.format, _audioSpec.silence, _audioSpec.samples, _audioSpec.padding, _audioSpec.size);
+
   inited = kAudioDeviceInited;
 
   if (!_fifo.init(_audioSpec.size * 4))
@@ -231,7 +234,7 @@ bool Application::init(const char* title, int width, int height)
   SDL_PauseAudioDevice(_audioDev, 0);
 
   // Initialize the rest of the components
-  if (!_audio.init(&_logger, (double)_audioSpec.freq, &_fifo))
+  if (!_audio.init(&_logger, (double)_audioSpec.freq, _audioSpec.channels, &_fifo))
   {
     goto error;
   }

--- a/src/components/Audio.cpp
+++ b/src/components/Audio.cpp
@@ -126,15 +126,15 @@ size_t Fifo::free()
   return avail;
 }
 
-bool Audio::init(libretro::LoggerComponent* logger, double sample_rate, Fifo* fifo)
+bool Audio::init(libretro::LoggerComponent* logger, double sample_rate, int channels, Fifo* fifo)
 {
   _coreRate = 0;
   _resampler = NULL;
 
   _logger = logger;
   _sampleRate = sample_rate;
+  _channels = channels;
 
-  _rateControlDelta = 0.005;
   _currentRatio = 0.0;
   _originalRatio = 0.0;
 
@@ -178,51 +178,115 @@ bool Audio::setRate(double rate)
 
 void Audio::mix(const int16_t* samples, size_t frames)
 {
-  _logger->debug(TAG "Requested %zu audio frames", frames);
+  _logger->debug(TAG "Processing %zu audio frames", frames);
 
   size_t avail = _fifo->free();
+  size_t output_size;
+  int16_t* output;
+  spx_uint32_t out_len;
 
-  /* Readjust the audio input rate. */
-  int    half_size = (int)_fifo->size() / 2;
-  int    delta_mid = (int)avail - half_size;
-  double direction = (double)delta_mid / (double)half_size;
-  double adjust    = 1.0 + _rateControlDelta * direction;
-
-  _currentRatio = _originalRatio * adjust;
-
-  _logger->debug(TAG "Original ratio %f adjusted by %f to %f", _originalRatio, adjust, _currentRatio);
-
-  spx_uint32_t in_len = frames * 2;
-  spx_uint32_t out_len = (spx_uint32_t)(in_len * _currentRatio);
-  out_len += out_len & 1; // request an even number of samples (stereo)
-  int16_t* output = (int16_t*)alloca(out_len * 2);
-
-  if (output == NULL)
+  if (_sampleRate == _coreRate)
   {
-    _logger->error(TAG "Error allocating output buffer");
-    return;
+    /* no resampling needed */
+    output = (int16_t*)samples;
+    out_len = frames * 2;
+    output_size = frames * 2 * sizeof(int16_t);
+  }
+  else
+  {
+    // /* adjust the audio input rate. */
+    //const int    half_size = (int)_fifo->size() / 2;
+    //const int    delta_mid = (int)avail - half_size;
+    //const double direction = (double)delta_mid / (double)half_size;
+    //const double rateControlDelta = 0.005;
+    //const double adjust = 1.0 + rateControlDelta * direction;
+
+    //_currentRatio = _originalRatio * adjust;
+
+    //if (_currentRatio != _originalRatio)
+    //  _logger->debug(TAG "Original ratio %f adjusted by %f to %f", _originalRatio, adjust, _currentRatio);
+
+    /* allocate output buffer */
+    out_len = (spx_uint32_t)(frames * 2 * _currentRatio);
+    out_len += (out_len & 1);  /* don't send incomplete frames */
+
+    output_size = out_len * sizeof(int16_t);
+    output = (int16_t*)alloca(output_size);
+
+    if (output == NULL)
+    {
+      _logger->error(TAG "Error allocating audio resampling output buffer");
+      return;
+    }
+
+    /* do the resampling */
+    spx_uint32_t in_len = frames * 2; /* input is 2-channel */
+    _logger->debug(TAG "Resampling %u samples to %u", in_len, out_len);
+    int error = speex_resampler_process_int(_resampler, 0, samples, &in_len, output, &out_len);
+
+    if (error != RESAMPLER_ERR_SUCCESS)
+    {
+      memset(output, 0, output_size);
+      _logger->error(TAG "speex_resampler_process_int: %s", speex_resampler_strerror(error));
+    }
   }
 
-  _logger->debug(TAG "Resampling %u samples to %u", in_len, out_len);
-  int error = speex_resampler_process_int(_resampler, 0, samples, &in_len, output, &out_len);
-  _logger->debug(TAG "Resampled  %u samples to %u", in_len, out_len);
-
-  if (error != RESAMPLER_ERR_SUCCESS)
+  /* flush to FIFO queue */
+  const size_t needed = (output_size / 2) * _channels;
+  while (avail < needed)
   {
-    memset(output, 0, out_len * 2);
-    _logger->error(TAG "speex_resampler_process_int: %s", speex_resampler_strerror(error));
-  }
-
-  out_len &= ~1; // don't send incomplete audio frames
-  size_t size = out_len * 2;
-  
-  while (size > avail)
-  {
-    _logger->debug(TAG "Requested %zu bytes but only %zu available, sleeping", size, avail);
+    _logger->debug(TAG "Waiting for FIFO (need %zu bytes but only %zu available), sleeping", needed, avail);
     SDL_Delay(1);
     avail = _fifo->free();
   }
 
-  _fifo->write(output, size);
-  _logger->debug(TAG "Wrote %zu bytes to the FIFO", size);
+  if (_channels == 2)
+  {
+    /* input is 2 channels, output is 2 channels, just flush it */
+    _fifo->write(output, output_size);
+  }
+  else
+  {
+    /* input is 2 channels, have to add silence for other channels */
+    int16_t* read = output;
+    int16_t* stop = output + out_len;
+    const size_t flush_frames = 64;
+    int16_t* expanded = (int16_t*)alloca(flush_frames * _channels * sizeof(int16_t));
+    int16_t* write = expanded;
+    int count = 0;
+
+    if (expanded == NULL)
+    {
+      _logger->error(TAG "Error allocating audio channel expansion buffer");
+      return;
+    }
+
+    while (read < stop)
+    {
+      *write++ = *read++;
+      if (_channels > 1)
+      {
+        *write++ = *read++;
+
+        for (int i = 2; i < _channels; ++i)
+          *write++ = 0;
+      }
+      else
+      {
+        ++read;
+      }
+
+      if (++count == flush_frames)
+      {
+        _fifo->write(expanded, flush_frames * _channels * sizeof(int16_t));
+        write = expanded;
+        count = 0;
+      }
+    }
+
+    if (count > 0)
+      _fifo->write(expanded, count * _channels * sizeof(int16_t));
+  }
+
+  _logger->debug(TAG "Wrote %zu bytes to the FIFO", needed);
 }

--- a/src/components/Audio.h
+++ b/src/components/Audio.h
@@ -52,7 +52,7 @@ protected:
 class Audio: public libretro::AudioComponent
 {
 public:
-  bool init(libretro::LoggerComponent* logger, double sample_rate, Fifo* fifo);
+  bool init(libretro::LoggerComponent* logger, double sample_rate, int channels, Fifo* fifo);
   void destroy();
 
   virtual bool setRate(double rate) override;
@@ -63,8 +63,8 @@ protected:
 
   double _sampleRate;
   double _coreRate;
+  int _channels;
 
-  double _rateControlDelta;
   double _currentRatio;
   double _originalRatio;
   SpeexResamplerState* _resampler;

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -384,6 +384,7 @@ void libretro::Core::step(bool generate_audio)
   
   if (generate_audio && _samplesCount > 0)
   {
+    // _samples are 2-channel (stereo)
     _audio->mix(_samples, _samplesCount / 2);
   }
 }


### PR DESCRIPTION
fixes #164 

The code was writing a 16-bit 44KHz stereo signal to the audio device. If the audio device was expecting more channels, this resulted in the device getting less data than it expected, so the sample ended too soon. For reasons that are unclear to me, the audio output is largely responsible for the speed of the emulator if the emulator is not limited by the CPU. There doesn't seem to be any sort of timer or sleeping mechanism to ensure the proper framerate is not exceeded.

I've also made a couple of optimizations for the "expected" settings. If the core is providing 44KHz audio, we don't try to resample. I've also removed the code that attempts to dynamically adjust the resample ratio as it doesn't seem to be necessary.