### PR TITLE
add opengl hardware rendering support

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2127,7 +2127,7 @@ void Application::loadState(const std::string& path)
   enum retro_pixel_format format;
   _video.getFramebufferSize(&width, &height, &format);
 
-  const void* pixels = util::loadImage(&_logger, path + ".png", &width, &height, &pitch);
+  void* pixels = util::loadImage(&_logger, path + ".png", &width, &height, &pitch);
 
   if (pixels == NULL)
   {
@@ -2135,7 +2135,7 @@ void Application::loadState(const std::string& path)
     return;
   }
 
-  const void* converted = util::fromRgb(&_logger, pixels, width, height, &pitch, format);
+  void* converted = util::fromRgb(&_logger, pixels, width, height, &pitch, format);
 
   if (converted == NULL)
   {

--- a/src/Application.h
+++ b/src/Application.h
@@ -32,6 +32,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include "components/Config.h"
 #include "components/Input.h"
 #include "components/Logger.h"
+#include "components/VideoContext.h"
 #include "components/Video.h"
 
 #include "Emulator.h"
@@ -137,12 +138,13 @@ protected:
   SDL_AudioSpec     _audioSpec;
   SDL_AudioDeviceID _audioDev;
 
-  Fifo   _fifo;
-  Logger _logger;
-  Config _config;
-  Video  _video;
-  Audio  _audio;
-  Input  _input;
+  Fifo         _fifo;
+  Logger       _logger;
+  Config       _config;
+  VideoContext _videoContext;
+  Video        _video;
+  Audio        _audio;
+  Input        _input;
 
   KeyBinds _keybinds;
   std::vector<RecentItem> _recentList;

--- a/src/Gl.cpp
+++ b/src/Gl.cpp
@@ -16,6 +16,7 @@ static PFNGLBINDBUFFERPROC s_glBindBuffer;
 static PFNGLBUFFERDATAPROC s_glBufferData;
 static PFNGLVERTEXATTRIBPOINTERPROC s_glVertexAttribPointer;
 static PFNGLENABLEVERTEXATTRIBARRAYPROC s_glEnableVertexAttribArray;
+static PFNGLDISABLEVERTEXATTRIBARRAYPROC s_glDisableVertexAttribArray;
 
 static PFNGLCREATESHADERPROC s_glCreateShader;
 static PFNGLDELETESHADERPROC s_glDeleteShader;
@@ -49,6 +50,8 @@ static PFNGLGENRENDERBUFFERSPROC s_glGenRenderbuffers;
 static PFNGLDELETERENDERBUFFERSPROC s_glDeleteRenderbuffers;
 static PFNGLBINDRENDERBUFFERPROC s_glBindRenderbuffer;
 static PFNGLRENDERBUFFERSTORAGEPROC s_glRenderbufferStorage;
+
+static PFNGLBLENDEQUATIONEXTPROC s_glBlendEquationEXT;
 
 static void* getProcAddress(const char* symbol)
 {
@@ -114,6 +117,7 @@ void Gl::init(libretro::LoggerComponent* logger)
   s_glBufferData = (PFNGLBUFFERDATAPROC)getProcAddress("glBufferData");
   s_glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)getProcAddress("glVertexAttribPointer");
   s_glEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)getProcAddress("glEnableVertexAttribArray");
+  s_glDisableVertexAttribArray = (PFNGLDISABLEVERTEXATTRIBARRAYPROC)getProcAddress("glDisableVertexAttribArray");
 
   s_glCreateShader = (PFNGLCREATESHADERPROC)getProcAddress("glCreateShader");
   s_glDeleteShader = (PFNGLDELETESHADERPROC)getProcAddress("glDeleteShader");
@@ -147,11 +151,25 @@ void Gl::init(libretro::LoggerComponent* logger)
 
   s_glGenRenderbuffers = (PFNGLGENRENDERBUFFERSPROC)getProcAddress("glGenRenderbuffers");
   s_glDeleteRenderbuffers = (PFNGLDELETERENDERBUFFERSPROC)getProcAddress("glDeleteRenderbuffers");
+
+  s_glBlendEquationEXT = (PFNGLBLENDEQUATIONEXTPROC)getProcAddress("glBlendEquationEXT");
 }
 
 bool Gl::ok()
 {
   return s_ok;
+}
+
+GLenum Gl::getError()
+{
+  return glGetError();
+}
+
+void Gl::getIntegerv(GLenum pname, GLint *params)
+{
+  if (!s_ok) return;
+  glGetIntegerv(pname, params);
+  check(__FUNCTION__);
 }
 
 void Gl::genTextures(GLsizei n, GLuint* textures)
@@ -210,6 +228,13 @@ void Gl::getTexImage(GLenum target, GLint level, GLenum format, GLenum type, GLv
   check(__FUNCTION__);
 }
 
+void Gl::pixelStorei(GLenum pname, GLint param)
+{
+  if (!s_ok) return;
+  glPixelStorei(pname, param);
+  check(__FUNCTION__);
+}
+
 void Gl::genBuffers(GLsizei n, GLuint* buffers)
 {
   if (!s_ok || s_glGenBuffers == NULL) return;
@@ -249,6 +274,13 @@ void Gl::enableVertexAttribArray(GLuint index)
 {
   if (!s_ok || s_glEnableVertexAttribArray == NULL) return;
   s_glEnableVertexAttribArray(index);
+  check(__FUNCTION__);
+}
+
+void Gl::disableVertexAttribArray(GLuint index)
+{
+  if (!s_ok || s_glDisableVertexAttribArray == NULL) return;
+  s_glDisableVertexAttribArray(index);
   check(__FUNCTION__);
 }
 
@@ -492,6 +524,13 @@ void Gl::blendFunc(GLenum sfactor, GLenum dfactor)
 {
   if (!s_ok) return;
   glBlendFunc(sfactor, dfactor);
+  check(__FUNCTION__);
+}
+
+void Gl::blendEquation(GLenum mode)
+{
+  if (!s_ok || !s_glBlendEquationEXT) return;
+  s_glBlendEquationEXT(mode);
   check(__FUNCTION__);
 }
 

--- a/src/Gl.cpp
+++ b/src/Gl.cpp
@@ -14,6 +14,9 @@ static PFNGLGENBUFFERSPROC s_glGenBuffers;
 static PFNGLDELETEBUFFERSPROC s_glDeleteBuffers;
 static PFNGLBINDBUFFERPROC s_glBindBuffer;
 static PFNGLBUFFERDATAPROC s_glBufferData;
+static PFNGLGENVERTEXARRAYSPROC s_glGenVertexArrays;
+static PFNGLDELETEVERTEXARRAYSPROC s_glDeleteVertexArrays;
+static PFNGLBINDVERTEXARRAYPROC s_glBindVertexArray;
 static PFNGLVERTEXATTRIBPOINTERPROC s_glVertexAttribPointer;
 static PFNGLENABLEVERTEXATTRIBARRAYPROC s_glEnableVertexAttribArray;
 static PFNGLDISABLEVERTEXATTRIBARRAYPROC s_glDisableVertexAttribArray;
@@ -115,6 +118,9 @@ void Gl::init(libretro::LoggerComponent* logger)
   s_glDeleteBuffers = (PFNGLDELETEBUFFERSPROC)getProcAddress("glDeleteBuffers");
   s_glBindBuffer = (PFNGLBINDBUFFERPROC)getProcAddress("glBindBuffer");
   s_glBufferData = (PFNGLBUFFERDATAPROC)getProcAddress("glBufferData");
+  s_glGenVertexArrays = (PFNGLGENVERTEXARRAYSPROC)getProcAddress("glGenVertexArrays");
+  s_glDeleteVertexArrays = (PFNGLDELETEVERTEXARRAYSPROC)getProcAddress("glDeleteVertexArrays");
+  s_glBindVertexArray = (PFNGLBINDVERTEXARRAYPROC)getProcAddress("glBindVertexArray");
   s_glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)getProcAddress("glVertexAttribPointer");
   s_glEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)getProcAddress("glEnableVertexAttribArray");
   s_glDisableVertexAttribArray = (PFNGLDISABLEVERTEXATTRIBARRAYPROC)getProcAddress("glDisableVertexAttribArray");
@@ -260,6 +266,27 @@ void Gl::bufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum u
 {
   if (!s_ok || s_glBufferData == NULL) return;
   s_glBufferData(target, size, data, usage);
+  check(__FUNCTION__);
+}
+
+void Gl::genVertexArray(GLsizei n, GLuint *arrays)
+{
+  if (!s_ok || s_glGenVertexArrays == NULL) return;
+  s_glGenVertexArrays(n, arrays);
+  check(__FUNCTION__);
+}
+
+void Gl::deleteVertexArrays(GLsizei n, const GLuint *arrays)
+{
+  if (!s_ok || s_glDeleteVertexArrays == NULL) return;
+  s_glDeleteVertexArrays(n, arrays);
+  check(__FUNCTION__);
+}
+
+void Gl::bindVertexArray(GLuint array)
+{
+  if (!s_ok || s_glBindVertexArray == NULL) return;
+  s_glBindVertexArray(array);
   check(__FUNCTION__);
 }
 

--- a/src/Gl.h
+++ b/src/Gl.h
@@ -6,64 +6,70 @@
 
 namespace Gl
 {
-	void init(libretro::LoggerComponent* logger);
+  void init(libretro::LoggerComponent* logger);
   bool ok();
 
-	void genTextures(GLsizei n, GLuint* textures);
-	void deleteTextures(GLsizei n, const GLuint* textures);
-	void bindTexture(GLenum target, GLuint texture);
+  GLenum getError();
+  void getIntegerv(GLenum pname, GLint *params);
+
+  void genTextures(GLsizei n, GLuint* textures);
+  void deleteTextures(GLsizei n, const GLuint* textures);
+  void bindTexture(GLenum target, GLuint texture);
   void activeTexture(GLenum texture);
-	void texParameteri(GLenum target, GLenum pname, GLint param);
-	void texImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data);
-	void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels);
-	void getTexImage(GLenum target, GLint level, GLenum format, GLenum type, GLvoid* pixels);
+  void texParameteri(GLenum target, GLenum pname, GLint param);
+  void texImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data);
+  void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels);
+  void getTexImage(GLenum target, GLint level, GLenum format, GLenum type, GLvoid* pixels);
+  void pixelStorei(GLenum pname, GLint param);
 
-	void genBuffers(GLsizei n, GLuint* buffers);
-	void deleteBuffers(GLsizei n, const GLuint* buffers);
-	void bindBuffer(GLenum target, GLuint buffer);
-	void bufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage);
-	void vertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid* pointer);
-	void enableVertexAttribArray(GLuint index);
+  void genBuffers(GLsizei n, GLuint* buffers);
+  void deleteBuffers(GLsizei n, const GLuint* buffers);
+  void bindBuffer(GLenum target, GLuint buffer);
+  void bufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage);
+  void vertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid* pointer);
+  void enableVertexAttribArray(GLuint index);
+  void disableVertexAttribArray(GLuint index);
 
-	GLuint createShader(GLenum shaderType);
-	void deleteShader(GLuint shader);
-	void shaderSource(GLuint shader, GLsizei count, const GLchar** string, const GLint* length);
-	void compileShader(GLuint shader);
-	void getShaderiv(GLuint shader, GLenum pname, GLint* params);
-	void getShaderInfoLog(GLuint shader, GLsizei maxLength, GLsizei* length, GLchar* infoLog);
+  GLuint createShader(GLenum shaderType);
+  void deleteShader(GLuint shader);
+  void shaderSource(GLuint shader, GLsizei count, const GLchar** string, const GLint* length);
+  void compileShader(GLuint shader);
+  void getShaderiv(GLuint shader, GLenum pname, GLint* params);
+  void getShaderInfoLog(GLuint shader, GLsizei maxLength, GLsizei* length, GLchar* infoLog);
 
-	GLuint createProgram();
-	void deleteProgram(GLuint program);
-	void attachShader(GLuint program, GLuint shader);
-	void linkProgram(GLuint program);
-	void validateProgram(GLuint program);
-	void getProgramiv(GLuint program, GLenum pname, GLint* params);
-	void getProgramInfoLog(GLuint program, GLsizei maxLength, GLsizei* length, GLchar* infoLog);
-	void useProgram(GLuint program);
-	GLint getAttribLocation(GLuint program, const GLchar* name);
-	GLint getUniformLocation(GLuint program, const GLchar* name);
+  GLuint createProgram();
+  void deleteProgram(GLuint program);
+  void attachShader(GLuint program, GLuint shader);
+  void linkProgram(GLuint program);
+  void validateProgram(GLuint program);
+  void getProgramiv(GLuint program, GLenum pname, GLint* params);
+  void getProgramInfoLog(GLuint program, GLsizei maxLength, GLsizei* length, GLchar* infoLog);
+  void useProgram(GLuint program);
+  GLint getAttribLocation(GLuint program, const GLchar* name);
+  GLint getUniformLocation(GLuint program, const GLchar* name);
   void uniform1i(GLint location, GLint v0);
-	void uniform2f(GLint location, GLfloat v0, GLfloat v1);
+  void uniform2f(GLint location, GLfloat v0, GLfloat v1);
 
-	void genFramebuffers(GLsizei n, GLuint* ids);
-	void deleteFramebuffers(GLsizei n, GLuint* ids);
-	void bindFramebuffer(GLenum target, GLuint framebuffer);
-	void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
-	void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
-	void drawBuffers(GLsizei n, const GLenum* bufs);
+  void genFramebuffers(GLsizei n, GLuint* ids);
+  void deleteFramebuffers(GLsizei n, GLuint* ids);
+  void bindFramebuffer(GLenum target, GLuint framebuffer);
+  void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+  void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
+  void drawBuffers(GLsizei n, const GLenum* bufs);
   GLenum checkFramebufferStatus(GLenum target);
 
-	void genRenderbuffers(GLsizei n, GLuint* renderbuffers);
-	void deleteRenderbuffers(GLsizei n, const GLuint* renderbuffers);
-	void bindRenderbuffer(GLenum target, GLuint renderbuffer);
-	void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+  void genRenderbuffers(GLsizei n, GLuint* renderbuffers);
+  void deleteRenderbuffers(GLsizei n, const GLuint* renderbuffers);
+  void bindRenderbuffer(GLenum target, GLuint renderbuffer);
+  void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
 
-	void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
-	void clear(GLbitfield mask);
-	void enable(GLenum cap);
-	void disable(GLenum cap);
-	void blendFunc(GLenum sfactor, GLenum dfactor);
-	void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
-	void drawArrays(GLenum mode, GLint first, GLsizei count);
+  void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
+  void clear(GLbitfield mask);
+  void enable(GLenum cap);
+  void disable(GLenum cap);
+  void blendFunc(GLenum sfactor, GLenum dfactor);
+  void blendEquation(GLenum mode);
+  void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
+  void drawArrays(GLenum mode, GLint first, GLsizei count);
 }
 

--- a/src/Gl.h
+++ b/src/Gl.h
@@ -26,6 +26,9 @@ namespace Gl
   void deleteBuffers(GLsizei n, const GLuint* buffers);
   void bindBuffer(GLenum target, GLuint buffer);
   void bufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage);
+  void genVertexArray(GLsizei n, GLuint *arrays);
+  void deleteVertexArrays(GLsizei n, const GLuint *arrays);
+  void bindVertexArray(GLuint array);
   void vertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid* pointer);
   void enableVertexAttribArray(GLuint index);
   void disableVertexAttribArray(GLuint index);

--- a/src/GlUtil.cpp
+++ b/src/GlUtil.cpp
@@ -21,6 +21,8 @@ GLuint GlUtil::createTexture(GLsizei width, GLsizei height, GLint internalFormat
 
   Gl::texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
   Gl::texParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+  Gl::texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  Gl::texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
   Gl::texImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, type, NULL);
 

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -229,6 +229,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     <ClCompile Include="components\Input.cpp" />
     <ClCompile Include="components\Logger.cpp" />
     <ClCompile Include="components\Video.cpp" />
+    <ClCompile Include="components\VideoContext.cpp" />
     <ClCompile Include="dynlib\dynlib.c" />
     <ClCompile Include="Emulator.cpp" />
     <ClCompile Include="Fsm.cpp" />
@@ -268,6 +269,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     <ClInclude Include="components\Input.h" />
     <ClInclude Include="components\Logger.h" />
     <ClInclude Include="components\Video.h" />
+    <ClInclude Include="components\VideoContext.h" />
     <ClInclude Include="dynlib\dynlib.h" />
     <ClInclude Include="Emulator.h" />
     <ClInclude Include="Fsm.h" />

--- a/src/RALibretro.vcxproj.filters
+++ b/src/RALibretro.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="rcheevos\src\rhash\md5.c">
       <Filter>Source Files\rhash</Filter>
     </ClCompile>
+    <ClCompile Include="components\VideoContext.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="About.h">
@@ -195,6 +198,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="GlUtil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="components\VideoContext.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -716,7 +716,7 @@ void util::saveImage(Logger* logger, const std::string& path, const void* data, 
   free((void*)pixels);
 }
 
-const void* util::fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format)
+void* util::fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format)
 {
   void* pixels;
 
@@ -827,7 +827,7 @@ const void* util::fromRgb(Logger* logger, const void* data, unsigned width, unsi
   return pixels;
 }
 
-const void* util::loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch)
+void* util::loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch)
 {
   FILE* f = util::openFile(logger, path, "rb");
   if (!f)

--- a/src/Util.h
+++ b/src/Util.h
@@ -68,8 +68,8 @@ namespace util
 
   const void* toRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void        saveImage(Logger* logger, const std::string& path, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
-  const void* fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format);
-  const void* loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch);
+  void*       fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format);
+  void*       loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch);
 
 #ifdef _WINDOWS
   std::string ucharToUtf8(const std::wstring& unicodeString);

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -30,11 +30,11 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAG "[VID] "
 
-bool Video::init(libretro::LoggerComponent* logger, Config* config, std::unique_ptr<VideoContext> ctx)
+bool Video::init(libretro::LoggerComponent* logger, libretro::VideoContextComponent *ctx, Config* config)
 {
   _logger = logger;
+  _ctx = ctx;
   _config = config;
-  _ctx = std::move(ctx);
 
   _enabled = true;
 

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -50,6 +50,10 @@ bool Video::init(libretro::LoggerComponent* logger, Config* config)
 
   _program = createProgram(&_posAttribute, &_uvAttribute, &_texUniform);
 
+  _hw.enabled = false;
+  _hw.frameBuffer = _hw.renderBuffer = 0;
+  _hw.callback = nullptr;
+
   if (!Gl::ok())
   {
     destroy();
@@ -78,6 +82,18 @@ void Video::destroy()
     Gl::deleteProgram(_program);
     _program = 0;
   }
+
+  if (_hw.frameBuffer != 0)
+  {
+    Gl::deleteFramebuffers(1, &_hw.frameBuffer);
+    _hw.frameBuffer = 0;
+  }
+
+  if (_hw.renderBuffer != 0)
+  {
+    Gl::deleteRenderbuffers(1, &_hw.renderBuffer);
+    _hw.renderBuffer = 0;
+  }
 }
 
 void Video::draw()
@@ -96,22 +112,29 @@ void Video::draw()
     Gl::uniform1i(_texUniform, 0);
 
     Gl::drawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    Gl::bindTexture(GL_TEXTURE_2D, 0);
+    Gl::disableVertexAttribArray(_posAttribute);
+    Gl::disableVertexAttribArray(_uvAttribute);
+    Gl::useProgram(0);
   }
 }
 
-bool Video::setGeometry(unsigned width, unsigned height, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback)
+bool Video::setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback)
 {
-  (void)hwRenderCallback;
+  bool hardwareRender = hwRenderCallback != nullptr;
+  if (!hardwareRender && _hw.enabled)
+    postHwRenderReset();
 
-  if (pixelFormat != _pixelFormat && _texture != 0)
-  {
-    _textureWidth = _textureHeight = 0;
-  }
+  _hw.enabled = hardwareRender;
+  _hw.callback = hwRenderCallback;
+
+  if (!ensureFramebuffer(maxWidth, maxHeight, pixelFormat, _linearFilter))
+    return false;
 
   _aspect = aspect;
-  _pixelFormat = pixelFormat;
 
-  _logger->debug(TAG "Geometry set to %u x %u (1:%f)", width, height, aspect);
+  _logger->debug(TAG "Geometry set to %u x %u (max %u x %u) (1:%f)", width, height, maxWidth, maxHeight, aspect);
   return true;
 }
 
@@ -119,68 +142,45 @@ void Video::refresh(const void* data, unsigned width, unsigned height, size_t pi
 {
   if (data != NULL && data != RETRO_HW_FRAME_BUFFER_VALID)
   {
-    bool updateVertexBuffer = false;
-    unsigned textureWidth = pitch;
-
-    switch (_pixelFormat)
-    {
-    case RETRO_PIXEL_FORMAT_XRGB8888: textureWidth /= 4; break;
-    case RETRO_PIXEL_FORMAT_RGB565:   // fallthrough
-    case RETRO_PIXEL_FORMAT_0RGB1555: // fallthrough
-    default:                          textureWidth /= 2; break;
-    }
-
-    if (textureWidth != _textureWidth || height != _textureHeight)
-    {
-      if (_texture != 0)
-      {
-        Gl::deleteTextures(1, &_texture);
-      }
-
-      _texture = createTexture(textureWidth, height, _pixelFormat, _linearFilter);
-
-      _textureWidth = textureWidth;
-      _textureHeight = height;
-
-      updateVertexBuffer = true;
-    }
-
     Gl::bindTexture(GL_TEXTURE_2D, _texture);
 
+    unsigned rowLength = pitch;
+    switch (_pixelFormat)
+    {
+    case RETRO_PIXEL_FORMAT_XRGB8888: rowLength /= 4; break;
+    case RETRO_PIXEL_FORMAT_RGB565:   // fallthrough
+    case RETRO_PIXEL_FORMAT_0RGB1555: // fallthrough
+    default:                          rowLength /= 2; break;
+    }
+
+    Gl::pixelStorei(GL_UNPACK_ROW_LENGTH, rowLength);
     switch (_pixelFormat)
     {
     case RETRO_PIXEL_FORMAT_XRGB8888:
-      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, textureWidth, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, data);
+      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, data);
       break;
       
     case RETRO_PIXEL_FORMAT_RGB565:
-      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, textureWidth, height, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, data);
+      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, data);
       break;
       
     case RETRO_PIXEL_FORMAT_0RGB1555:
     default:
-      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, textureWidth, height, GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, data);
+      Gl::texSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, data);
       break;
     }
 
-    _logger->debug(TAG "Texture refreshed with %u x %u pixels", textureWidth, height);
+    Gl::pixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    Gl::bindTexture(GL_TEXTURE_2D, 0);
 
-    if (width != _viewWidth || height != _viewHeight)
-    {
-      _viewWidth = width;
-      _viewHeight = height;
+    _logger->debug(TAG "Texture refreshed with %u x %u pixels", width, height);
 
-      updateVertexBuffer = true;
-    }
-
-    if (updateVertexBuffer)
-    {
-      float texScaleX = (float)_viewWidth / (float)_textureWidth;
-      float texScaleY = (float)_viewHeight / (float)_textureHeight;
-
-      Gl::deleteBuffers(1, &_vertexBuffer);
-      _vertexBuffer = createVertexBuffer(_windowWidth, _windowHeight, texScaleX, texScaleY, _posAttribute, _uvAttribute);
-    }
+    ensureView(width, height, _windowWidth, _windowHeight, _preserveAspect, _rotation);
+  }
+  else if (_hw.enabled && data == RETRO_HW_FRAME_BUFFER_VALID)
+  {
+    postHwRenderReset();
+    ensureView(width, height, _windowWidth, _windowHeight, _preserveAspect, _rotation);
   }
   else
   {
@@ -201,13 +201,20 @@ void Video::refresh(const void* data, unsigned width, unsigned height, size_t pi
 
 bool Video::supportsContext(enum retro_hw_context_type type)
 {
-  (void)type;
+  switch (type)
+  {
+    case RETRO_HW_CONTEXT_OPENGL:
+    case RETRO_HW_CONTEXT_OPENGL_CORE:
+      return true;
+  }
+
   return false;
 }
 
 uintptr_t Video::getCurrentFramebuffer()
 {
-  return 0;
+  _logger->debug(TAG "getCurrentFramebuffer() => %u", _hw.frameBuffer);
+  return _hw.frameBuffer;
 }
 
 retro_proc_address_t Video::getProcAddress(const char* symbol)
@@ -224,14 +231,8 @@ void Video::showMessage(const char* msg, unsigned frames)
 
 void Video::windowResized(unsigned width, unsigned height)
 {
-  _windowWidth = width;
-  _windowHeight = height;
   Gl::viewport(0, 0, width, height);
-
-  float texScaleX = (float)_viewWidth / (float)_textureWidth;
-  float texScaleY = (float)_viewHeight / (float)_textureHeight;
-
-  createVertexBuffer(width, height, texScaleX, texScaleY, _posAttribute, _uvAttribute);
+  ensureView(_viewWidth, _viewHeight, width, height, _preserveAspect, _rotation);
   _logger->debug(TAG "Window resized to %u x %u", width, height);
 }
 
@@ -261,10 +262,24 @@ void Video::getFramebufferSize(unsigned* width, unsigned* height, enum retro_pix
   *format = _pixelFormat;
 }
 
+static void verticalFlipRawTexture(uint8_t *data, unsigned height, unsigned pitch)
+{
+  uint8_t *swapSpace = (uint8_t*)malloc(pitch);
+  for (uint8_t *top = data, *bottom = (data + ((height - 1) * pitch));
+    top < bottom;
+    top += pitch, bottom -= pitch)
+  {
+    memcpy(swapSpace, top, pitch);
+    memcpy(top, bottom, pitch);
+    memcpy(bottom, swapSpace, pitch);
+  }
+  free(swapSpace);
+}
+
 const void* Video::getFramebuffer(unsigned* width, unsigned* height, unsigned* pitch, enum retro_pixel_format* format)
 {
   unsigned bpp = _pixelFormat == RETRO_PIXEL_FORMAT_XRGB8888 ? 4 : 2;
-  void* pixels = malloc(_textureWidth * _textureHeight * bpp);
+  uint8_t* pixels = (uint8_t*)malloc(_textureWidth * _textureHeight * bpp);
 
   if (pixels == NULL)
   {
@@ -289,6 +304,9 @@ const void* Video::getFramebuffer(unsigned* width, unsigned* height, unsigned* p
     break;
   }
 
+  if (_hw.enabled && _hw.callback->bottom_left_origin)
+    verticalFlipRawTexture(pixels, _textureHeight, _textureWidth * bpp);
+
   *width = _viewWidth;
   *height = _viewHeight;
   *pitch = _textureWidth * bpp;
@@ -297,9 +315,13 @@ const void* Video::getFramebuffer(unsigned* width, unsigned* height, unsigned* p
   return pixels;
 }
 
-void Video::setFramebuffer(const void* pixels, unsigned width, unsigned height, unsigned pitch)
+void Video::setFramebuffer(void* pixels, unsigned width, unsigned height, unsigned pitch)
 {
-  auto p = (const uint8_t*)pixels;
+  auto p = (uint8_t*)pixels;
+
+  if (_hw.enabled && _hw.callback->bottom_left_origin)
+    verticalFlipRawTexture(p, height, pitch);
+
   Gl::bindTexture(GL_TEXTURE_2D, _texture);
 
   switch (_pixelFormat)
@@ -402,10 +424,12 @@ void Video::showDialog()
 
   WORD y = 0;
 
-  db.addCheckbox("Preserve aspect ratio", 51001, 0, y, WIDTH - 10, 8, &_preserveAspect);
+  bool preserveAspect = _preserveAspect;
+  db.addCheckbox("Preserve aspect ratio", 51001, 0, y, WIDTH - 10, 8, &preserveAspect);
   y += LINE;
 
-  db.addCheckbox("Linear filtering", 51002, 0, y, WIDTH - 10, 8, &_linearFilter);
+  bool linearFilter = _linearFilter;
+  db.addCheckbox("Linear filtering", 51002, 0, y, WIDTH - 10, 8, &linearFilter);
   y += LINE;
 
   int rotation = (int)_rotation;
@@ -416,49 +440,16 @@ void Video::showDialog()
   db.addButton("OK", IDOK, WIDTH - 55 - 50, y, 50, 14, true);
   db.addButton("Cancel", IDCANCEL, WIDTH - 50, y, 50, 14, false);
 
-  bool preserveAspect = _preserveAspect;
-  bool linearFilter = _linearFilter;
-
   if (db.show())
   {
-    if (linearFilter != _linearFilter)
-    {
-      if (_texture != 0)
-      {
-        Gl::deleteTextures(1, &_texture);
-      }
-
-      _texture = createTexture(_textureWidth, _textureHeight, _pixelFormat, _linearFilter);
-    }
-
-    setRotation((Rotation)rotation);
-
-    if (preserveAspect != _preserveAspect)
-    {
-      float texScaleX = (float)_viewWidth / (float)_textureWidth;
-      float texScaleY = (float)_viewHeight / (float)_textureHeight;
-
-      Gl::deleteBuffers(1, &_vertexBuffer);
-      _vertexBuffer = createVertexBuffer(_windowWidth, _windowHeight, texScaleX, texScaleY, _posAttribute, _uvAttribute);
-    }
+    ensureFramebuffer(_textureWidth, _textureHeight, _pixelFormat, linearFilter);
+    ensureView(_viewWidth, _viewHeight, _windowWidth, _windowHeight, preserveAspect, static_cast<Rotation>(rotation));
   }
 }
 
 void Video::setRotation(Rotation rotation)
 {
-  if (rotation == _rotation)
-    return;
-
-  if (_rotationHandler)
-    _rotationHandler(_rotation, rotation);
-
-  _rotation = rotation;
-
-  float texScaleX = (float)_viewWidth / (float)_textureWidth;
-  float texScaleY = (float)_viewHeight / (float)_textureHeight;
-
-  Gl::deleteBuffers(1, &_vertexBuffer);
-  _vertexBuffer = createVertexBuffer(_windowWidth, _windowHeight, texScaleX, texScaleY, _posAttribute, _uvAttribute);
+  ensureView(_viewWidth, _viewHeight, _windowWidth, _windowHeight, _preserveAspect, rotation);
 }
 
 GLuint Video::createProgram(GLint* pos, GLint* uv, GLint* tex)
@@ -514,6 +505,14 @@ GLuint Video::createVertexBuffer(unsigned windowWidth, unsigned windowHeight, fl
   else
   {
     winScaleX = winScaleY = 1.0f;
+  }
+
+  if (_hw.enabled && _hw.callback->bottom_left_origin)
+  {
+    if (_rotation == Rotation::Ninety || _rotation == Rotation::TwoSeventy)
+      winScaleX = -winScaleX;
+    else
+      winScaleY = -winScaleY;
   }
 
   const VertexData vertexData0[] = {
@@ -597,4 +596,113 @@ GLuint Video::createTexture(unsigned width, unsigned height, retro_pixel_format 
 
   _logger->debug(TAG "Texture created with dimensions %u x %u (%s, %s)", width, height, format, linear ? "linear" : "nearest");
   return texture;
+}
+
+bool Video::ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter)
+{
+  if (_texture == 0
+    || (_hw.enabled && _hw.frameBuffer == 0)
+    || width > _textureWidth || height > _textureHeight
+    || pixelFormat != _pixelFormat
+    || linearFilter != _linearFilter)
+  {
+    if (_texture != 0)
+    {
+      Gl::deleteTextures(1, &_texture);
+    }
+
+    _texture = createTexture(width, height, pixelFormat, linearFilter);
+    if (_texture == 0)
+    {
+      _logger->error(TAG " ensure framebuffer: failed to create texture %u x %u (%d)", width, height, pixelFormat);
+      return false;
+    }
+
+    _textureWidth = width;
+    _textureHeight = height;
+    _pixelFormat = pixelFormat;
+    _linearFilter = linearFilter;
+
+    if (_hw.frameBuffer != 0)
+    {
+      Gl::deleteRenderbuffers(1, &_hw.renderBuffer);
+      Gl::deleteFramebuffers(1, &_hw.frameBuffer);
+      _hw.renderBuffer = _hw.frameBuffer = 0;
+    }
+
+    if (_hw.enabled)
+    {
+      _hw.frameBuffer = GlUtil::createFramebuffer(&_hw.renderBuffer, width, height, _texture, _hw.callback->depth, _hw.callback->stencil);
+      if (_hw.frameBuffer == 0)
+      {
+        _logger->error(TAG " ensure framebuffer: failed to create hardware render framebuffer %u x %u", width, height);
+        return false;
+      }
+    }
+
+    // force the view to be updated as well
+    _viewWidth = _viewHeight = 0;
+  }
+
+  return true;
+}
+
+bool Video::ensureView(unsigned width, unsigned height, unsigned windowWidth, unsigned windowHeight, bool preserveAspect, Rotation rotation)
+{
+  if (width != _viewWidth || height != _viewHeight
+    || windowWidth != _windowWidth || windowHeight != _windowHeight
+    || preserveAspect != _preserveAspect
+    || rotation != _rotation)
+  {
+    _preserveAspect = preserveAspect;
+
+    if (rotation != _rotation)
+    {
+      if (_rotationHandler)
+        _rotationHandler(_rotation, rotation);
+      _rotation = rotation;
+    }
+
+    if (_vertexBuffer != 0)
+      Gl::deleteBuffers(1, &_vertexBuffer);
+
+    float texScaleX = (float)width / (float)_textureWidth;
+    float texScaleY = (float)height / (float)_textureHeight;
+
+    _vertexBuffer = createVertexBuffer(windowWidth, windowHeight, texScaleX, texScaleY, _posAttribute, _uvAttribute);
+    if (_vertexBuffer == 0)
+    {
+      _logger->error(TAG " failed to ensure view: %u x %u", width, height);
+      return false;
+    }
+
+    _viewWidth = width;
+    _viewHeight = height;
+
+    _windowWidth = windowWidth;
+    _windowHeight = windowHeight;
+  }
+
+  return true;
+}
+
+void Video::postHwRenderReset() const
+{
+  // when hardware rendering, the core may leave behind OpenGL
+  // state that interferes with our own software rendering
+
+  Gl::getError();  // clear the error flag, it's not ours
+
+  Gl::disable(GL_SCISSOR_TEST);
+  Gl::disable(GL_DEPTH_TEST);
+  Gl::disable(GL_CULL_FACE);
+  Gl::disable(GL_DITHER);
+  Gl::disable(GL_STENCIL_TEST);
+  Gl::disable(GL_BLEND);
+  Gl::blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  Gl::blendEquation(GL_FUNC_ADD);
+  Gl::clearColor(0.0, 0.0, 0.0, 1.0);
+
+  Gl::bindFramebuffer(GL_FRAMEBUFFER, 0);
+  Gl::viewport(0, 0, _windowWidth, _windowHeight);
 }

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -490,13 +490,31 @@ GLuint Video::createVertexBuffer(unsigned windowWidth, unsigned windowHeight, fl
 
   if (_preserveAspect)
   {
-    unsigned h = windowHeight;
-    unsigned w = (unsigned)(windowHeight * _aspect);
-
-    if (w > windowWidth)
+    unsigned w, h;
+    switch (_rotation)
     {
-      w = windowWidth;
-      h = (unsigned)(windowWidth / _aspect);
+      default:
+      case Rotation::None:
+      case Rotation::OneEighty:
+        h = windowHeight;
+        w = (unsigned)(windowHeight * _aspect);
+        if (w > windowWidth)
+        {
+          w = windowWidth;
+          h = (unsigned)(windowWidth / _aspect);
+        }
+        break;
+
+      case Rotation::Ninety:
+      case Rotation::TwoSeventy:
+        w = windowWidth;
+        h = (unsigned)(windowWidth * _aspect);
+        if (h > windowHeight)
+        {
+          h = windowHeight;
+          w = (unsigned)(windowHeight / _aspect);
+        }
+        break;
     }
 
     winScaleX = (float)w / (float)windowWidth;

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -330,7 +330,7 @@ const void* Video::getFramebuffer(unsigned* width, unsigned* height, unsigned* p
   }
 
   if (_hw.enabled && _hw.callback->bottom_left_origin)
-    verticalFlipRawTexture(pixels, _textureHeight, _textureWidth * bpp);
+    verticalFlipRawTexture(pixels, _viewHeight, _textureWidth * bpp);
 
   *width = _viewWidth;
   *height = _viewHeight;

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -25,33 +25,10 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <SDL_opengl.h>
 
-class VideoContext
-{
-public:
-  virtual void swapBuffers() = 0;
-};
-
-template<typename SwapBuffersF>
-class VideoContextImpl: public VideoContext
-{
-public:
-  VideoContextImpl(SwapBuffersF swapBuffers) : _swapBuffers(swapBuffers) {}
-  void swapBuffers() override { _swapBuffers(); }
-
-protected:
-  SwapBuffersF _swapBuffers;
-};
-
-template<typename SwapBuffersF>
-auto makeVideoContext(SwapBuffersF swapBuffers)
-{
-  return std::make_unique<VideoContextImpl<SwapBuffersF>>(swapBuffers);
-}
-
 class Video: public libretro::VideoComponent
 {
 public:
-  bool init(libretro::LoggerComponent* logger, Config* config, std::unique_ptr<VideoContext> context);
+  bool init(libretro::LoggerComponent* logger, libretro::VideoContextComponent* ctx, Config* config);
   void destroy();
 
   virtual void setEnabled(bool enabled) override;
@@ -98,8 +75,8 @@ protected:
   void postHwRenderReset() const;
 
   libretro::LoggerComponent* _logger;
+  libretro::VideoContextComponent* _ctx;
   Config* _config;
-  std::unique_ptr<VideoContext> _ctx;
 
   bool                    _enabled;
 

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -33,7 +33,7 @@ public:
 
   void draw();
 
-  virtual bool setGeometry(unsigned width, unsigned height, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override;
+  virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override;
   virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) override;
 
   virtual bool                 supportsContext(enum retro_hw_context_type type) override;
@@ -45,7 +45,7 @@ public:
   void windowResized(unsigned width, unsigned height);
   void getFramebufferSize(unsigned* width, unsigned* height, enum retro_pixel_format* format);
   const void* getFramebuffer(unsigned* width, unsigned* height, unsigned* pitch, enum retro_pixel_format* format);
-  void setFramebuffer(const void* pixels, unsigned width, unsigned height, unsigned pitch);
+  void setFramebuffer(void* pixels, unsigned width, unsigned height, unsigned pitch);
 
   std::string serialize();
   void deserialize(const char* json);
@@ -67,6 +67,9 @@ protected:
   GLuint createProgram(GLint* pos, GLint* uv, GLint* tex);
   GLuint createVertexBuffer(unsigned windowWidth, unsigned windowHeight, float texScaleX, float texScaleY, GLint pos, GLint uv);
   GLuint createTexture(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linear);
+  bool ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter);
+  bool ensureView(unsigned width, unsigned height, unsigned windowWidth, unsigned windowHeight, bool preserveAspect, Rotation rotation);
+  void postHwRenderReset() const;
 
   libretro::LoggerComponent* _logger;
   Config* _config;
@@ -91,5 +94,12 @@ protected:
 
   bool                    _preserveAspect;
   bool                    _linearFilter;
+
+  struct {
+    bool enabled;
+    GLuint frameBuffer;
+    GLuint renderBuffer;
+    const retro_hw_render_callback *callback;
+  }                       _hw;
 };
 

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -65,7 +65,7 @@ public:
 
 protected:
   GLuint createProgram(GLint* pos, GLint* uv, GLint* tex);
-  GLuint createVertexBuffer(unsigned windowWidth, unsigned windowHeight, float texScaleX, float texScaleY, GLint pos, GLint uv);
+  bool ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float texScaleX, float texScaleY, GLint pos, GLint uv);
   GLuint createTexture(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linear);
   bool ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter);
   bool ensureView(unsigned width, unsigned height, unsigned windowWidth, unsigned windowHeight, bool preserveAspect, Rotation rotation);
@@ -78,6 +78,7 @@ protected:
   GLint                   _posAttribute;
   GLint                   _uvAttribute;
   GLint                   _texUniform;
+  GLuint                  _vertexArray;
   GLuint                  _vertexBuffer;
   GLuint                  _texture;
 

--- a/src/components/VideoContext.cpp
+++ b/src/components/VideoContext.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2018 Andre Leiradella
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "VideoContext.h"
+
+bool VideoContext::init(libretro::LoggerComponent* logger, SDL_Window* window)
+{
+  _logger = logger;
+  _window = window;
+
+  return true;
+}
+
+void VideoContext::destroy()
+{
+}
+
+void VideoContext::swapBuffers()
+{
+  SDL_GL_SwapWindow(_window);
+}

--- a/src/components/VideoContext.h
+++ b/src/components/VideoContext.h
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2018 Andre Leiradella
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "libretro/Components.h"
+
+#include <SDL.h>
+
+class VideoContext : public libretro::VideoContextComponent
+{
+public:
+  bool init(libretro::LoggerComponent* logger, SDL_Window* window);
+  void destroy();
+
+  virtual void swapBuffers() override;
+
+private:
+  libretro::LoggerComponent* _logger;
+  SDL_Window* _window;
+};

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -123,7 +123,7 @@ namespace libretro
   class VideoComponent
   {
   public:
-    virtual bool setGeometry(unsigned width, unsigned height, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) = 0;
+    virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) = 0;
     virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) = 0;
 
     virtual bool                 supportsContext(enum retro_hw_context_type type) = 0;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -123,6 +123,8 @@ namespace libretro
   class VideoComponent
   {
   public:
+    virtual void setEnabled(bool enabled) = 0;
+
     virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) = 0;
     virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) = 0;
 

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -118,6 +118,15 @@ namespace libretro
   };
 
   /**
+   * A component that provides access to the video context.
+   */
+  class VideoContextComponent
+  {
+  public:
+    virtual void swapBuffers() = 0;
+  };
+
+  /**
    * A Video component.
    */
   class VideoComponent
@@ -187,11 +196,12 @@ namespace libretro
 
   struct Components
   {
-    LoggerComponent*    logger;
-    ConfigComponent*    config;
-    VideoComponent*     video;
-    AudioComponent*     audio;
-    InputComponent*     input;
-    AllocatorComponent* allocator;
+    LoggerComponent*       logger;
+    ConfigComponent*       config;
+    VideoContextComponent* videoContext;
+    VideoComponent*        video;
+    AudioComponent*        audio;
+    InputComponent*        input;
+    AllocatorComponent*    allocator;
   };
 }

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -111,10 +111,12 @@ namespace
   class Video: public libretro::VideoComponent
   {
   public:
-    virtual bool setGeometry(unsigned width, unsigned height, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override
+    virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override
     {
       (void)width;
       (void)height;
+      (void)maxWidth;
+      (void)maxHeight;
       (void)pixelFormat;
       (void)hwRenderCallback;
       return false;
@@ -471,11 +473,6 @@ bool libretro::Core::initAV()
 {
   InstanceSetter instance_setter(this);
 
-  if (_needsHardwareRender)
-  {
-    _hardwareRenderCallback.context_reset();
-  }
-
   _core.setVideoRefresh(s_videoRefreshCallback);
   _core.setAudioSampleBatch(s_audioSampleBatchCallback);
   _core.setAudioSample(s_audioSampleCallback);
@@ -500,7 +497,7 @@ bool libretro::Core::initAV()
 
   const struct retro_hw_render_callback* cb = _needsHardwareRender ? &_hardwareRenderCallback : NULL;
 
-  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
+  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.max_width, _systemAVInfo.geometry.max_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
   {
     goto error;
   }
@@ -508,6 +505,11 @@ bool libretro::Core::initAV()
   if (!_audio->setRate(_systemAVInfo.timing.sample_rate))
   {
     goto error;
+  }
+
+  if (_needsHardwareRender)
+  {
+    _hardwareRenderCallback.context_reset();
   }
   
   return true;
@@ -910,7 +912,7 @@ bool libretro::Core::setSystemAVInfo(const struct retro_system_av_info* data)
 
   const struct retro_hw_render_callback* cb = _needsHardwareRender ? &_hardwareRenderCallback : NULL;
 
-  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
+  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.max_width, _systemAVInfo.geometry.max_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
   {
     return false;
   }
@@ -1207,7 +1209,7 @@ bool libretro::Core::setGeometry(const struct retro_game_geometry* data)
 
   const struct retro_hw_render_callback* cb = _needsHardwareRender ? &_hardwareRenderCallback : NULL;
 
-  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
+  if (!_video->setGeometry(_systemAVInfo.geometry.base_width, _systemAVInfo.geometry.base_height, _systemAVInfo.geometry.max_width, _systemAVInfo.geometry.max_height, _systemAVInfo.geometry.aspect_ratio, _pixelFormat, cb))
   {
     return false;
   }

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -108,6 +108,14 @@ namespace
     }
   };
 
+  class VideoContext : public libretro::VideoContextComponent
+  {
+  public:
+    virtual void swapBuffers() override
+    {
+    }
+  };
+
   class Video: public libretro::VideoComponent
   {
   public:
@@ -238,12 +246,13 @@ namespace
 }
 
 // Instances of the dummy components to use in CoreWrap instances by default
-static Logger    s_logger;
-static Config    s_config;
-static Video     s_video;
-static Audio     s_audio;
-static Input     s_input;
-static Allocator s_allocator;
+static Logger       s_logger;
+static Config       s_config;
+static VideoContext s_videoContext;
+static Video        s_video;
+static Audio        s_audio;
+static Input        s_input;
+static Allocator    s_allocator;
 
 // Helper function for the memory map interface
 static bool preprocessMemoryDescriptors(struct retro_memory_descriptor* descriptors, unsigned num_descriptors);
@@ -252,21 +261,23 @@ bool libretro::Core::init(const Components* components)
 {
   InstanceSetter instance_setter(this);
 
-  _logger    = &s_logger;
-  _config    = &s_config;
-  _video     = &s_video;
-  _audio     = &s_audio;
-  _input     = &s_input;
-  _allocator = &s_allocator;
+  _logger       = &s_logger;
+  _config       = &s_config;
+  _videoContext = &s_videoContext;
+  _video        = &s_video;
+  _audio        = &s_audio;
+  _input        = &s_input;
+  _allocator    = &s_allocator;
 
   if (components != NULL)
   {
-    if (components->logger != NULL)    _logger    = components->logger;
-    if (components->config != NULL)    _config    = components->config;
-    if (components->video != NULL)     _video     = components->video;
-    if (components->audio != NULL)     _audio     = components->audio;
-    if (components->input != NULL)     _input     = components->input;
-    if (components->allocator != NULL) _allocator = components->allocator;
+    if (components->logger != NULL)       _logger       = components->logger;
+    if (components->config != NULL)       _config       = components->config;
+    if (components->videoContext != NULL) _videoContext = components->videoContext;
+    if (components->video != NULL)        _video        = components->video;
+    if (components->audio != NULL)        _audio        = components->audio;
+    if (components->input != NULL)        _input        = components->input;
+    if (components->allocator != NULL)    _allocator    = components->allocator;
   }
 
   reset();

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -111,6 +111,11 @@ namespace
   class Video: public libretro::VideoComponent
   {
   public:
+    virtual void setEnabled(bool enabled) override
+    {
+      (void)enabled;
+    }
+
     virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override
     {
       (void)width;
@@ -362,7 +367,7 @@ void libretro::Core::destroy()
   reset();
 }
 
-void libretro::Core::step(bool generate_audio)
+void libretro::Core::step(bool generateVideo, bool generateAudio)
 {
   InstanceSetter instance_setter(this);
 
@@ -380,11 +385,13 @@ void libretro::Core::step(bool generate_audio)
     }
   }
 
+  _video->setEnabled(generateVideo);
+
   _samplesCount = 0;
 
   _core.run();
   
-  if (generate_audio && _samplesCount > 0)
+  if (generateAudio && _samplesCount > 0)
   {
     _audio->mix(_samples, _samplesCount / 2);
   }

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -195,6 +195,7 @@ namespace libretro
     
     LoggerComponent*                _logger;
     ConfigComponent*                _config;
+    VideoContextComponent*          _videoContext;
     VideoComponent*                 _video;
     AudioComponent*                 _audio;
     InputComponent*                 _input;

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -44,7 +44,7 @@ namespace libretro
 
     void destroy();
     
-    void step(bool generate_audio);
+    void step(bool generateVideo, bool generateAudio);
 
     unsigned getApiVersion();
     unsigned getRegion();


### PR DESCRIPTION
Closes #175.

Besides the hardware rendering, there are also two small bugfixes included (in individual commits).

**add opengl hardware rendering support**

If a core requests opengl hardware rendering, the video module creates a framebuffer according to the core-provided requirements and sets the render texture as its color attachment. The core gets the framebuffer through the `retro_hw_get_current_framebuffer_t` libretro callback.

Every frame, after the core is done rendering, it calls `retro_video_refresh_t` with `data = RETRO_HW_FRAME_BUFFER_VALID`, in which case we just make sure the view is set according to the provided `width` and `height` parameters, instead of placing the contents of `data` into the texture as would happen in a software rendering configuration.

When it's time for RALibretro to draw a frame, there is no difference between software and hardware rendering: the texture is still rendered to a full-window quad. This works because the core renders to the framebuffer to which the rendered texture is set as a color attachment.

----

Hardware rendering cores can choose to use the opengl coordinate system where (0,0) is bottom-left, whilst it would be top-left in the usual libretro coord system that's used in software rendering.

If the core requests bottom-left coordinates, the vertex buffer is set so that the texture is flipped vertically in 0º and 180º rotations, and flipped horizontally in 90º and 270º rotations.

Images generated by screenshots and save states are also flipped vertically, though in this case the flip is performed by the video module itself on the raw texture data.

----

Because the core and the frontend share the opengl context, it's possible for them to screw with each other by leaving non-default opengl state behind. To protect the core from the frontend, the video module was updated to reset the opengl state it uses. To protect the frontend from the core, the video module sets a bunch of opengl state back to defaults after the core is done rendering a frame (`postHwRenderReset`). This reset is also performed when we switch from hardware to software rendering.

----

Finally, most of the code dealing with resizing the framebuffer, setting the viewport, creating the vertex buffer, etc... was refactored into two methods: `ensureFramebuffer` and `ensureView`. This avoids the duplication of the somewhat complex logic that was getting hard to manage.

Related to this, the render texture's size is now only updated when the core changes its max width or height, instead of whenever the frame's dimensions (the view) change.

----

**fix texture wrapping**

The texture rendered to the whole-window quad was using `GL_REPEAT` wrapping. Because coord 1.0 is slightly beyond the end of the texture, the bottom row of pixels would be rendered as the result of filtering the bottom and top rows of the texture.

Fixed by setting the texture's wrapping to `GL_CLAMP_TO_EDGE`.

**fix aspect ratio when rotated 90 or 270 degrees**