### PR TITLE
remember config changes within a session

### DIFF
--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -373,6 +373,16 @@ void Config::showDialog(const std::string& coreName, Input& input)
       else
       {
         _selections[var._key] = var._options[var._selected];
+
+        // remember the selection for next time
+        for (auto& actualVar : _variables)
+        {
+          if (actualVar._key == var._key)
+          {
+            actualVar._selected = var._selected;
+            break;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
fixes an issue where config changes would appear to be lost if immediately reopening the dialog after making them.

the dialog copies the config settings so the controller items can be added. once changes are made, the selection is converted to a value and that was being persisted correctly, but the selected index also needed to be copied back into the original config setting object so the correct item would appear selected the next time the dialog was opened.