### PR TITLE
Allow subfolders for SRAM and save states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ OBJS=\
 	src/main.o \
 	src/Memory.o \
 	src/menu.res \
+	src/States.o \
 	src/Util.o
 
 %.o: %.cpp

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -810,6 +810,10 @@ void Application::saveConfiguration()
   json += ",\"bindings\":";
   json += _keybinds.serializeBindings();
 
+  // saves
+  json += ",\"saves\":";
+  json += _states.serializeSettings();
+
   // window position
   const Uint32 flags = SDL_GetWindowFlags(_window);
   if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP)
@@ -1209,7 +1213,7 @@ bool Application::loadGame(const std::string& path)
     free(data);
   }
 
-  _states.setGame(_gameFileName, _coreName, &_core);
+  _states.setGame(_gameFileName, _system, _coreName, &_core);
 
   // reset the vertical sync flag
   SDL_GL_SetSwapInterval(1);
@@ -1281,6 +1285,8 @@ moved_recent_item:
   _memory.attachToCore(&_core, _system);
 
   _validSlots = 0;
+
+  _states.migrateFiles();
 
   for (unsigned ndx = 1; ndx <= 10; ndx++)
   {
@@ -1935,6 +1941,13 @@ void Application::loadConfiguration()
       else if (ud->key == "bindings" && event == JSONSAX_OBJECT)
       {
         if (!ud->self->_keybinds.deserializeBindings(str))
+        {
+          return -1;
+        }
+      }
+      else if (ud->key == "saves" && event == JSONSAX_OBJECT)
+      {
+        if (!ud->self->_states.deserializeSettings(str))
         {
           return -1;
         }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1352,6 +1352,13 @@ bool Application::unloadGame()
 
   _video.clear();
 
+  _gamePath.clear();
+  _gameFileName.clear();
+  _states.setGame(_gameFileName, 0, _coreName, &_core);
+
+  _validSlots = 0;
+  enableSlots();
+
   return true;
 }
 
@@ -2139,6 +2146,10 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       _video.showDialog();
       break;
     
+    case IDM_SAVING_CONFIG:
+      _states.showDialog();
+      break;
+
     case IDM_WINDOW_1X:
     case IDM_WINDOW_2X:
     case IDM_WINDOW_3X:

--- a/src/Application.h
+++ b/src/Application.h
@@ -38,6 +38,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include "Emulator.h"
 #include "KeyBinds.h"
 #include "Memory.h"
+#include "States.h"
 
 class Application
 {
@@ -131,6 +132,7 @@ protected:
   Audio        _audio;
   Input        _input;
   Memory       _memory;
+  States       _states;
 
   KeyBinds _keybinds;
   std::vector<RecentItem> _recentList;

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -175,7 +175,11 @@ static const struct retro_memory_descriptor* getDescriptor(const struct retro_me
     {
       /* otherwise, attempt to match the address by matching the select bits */
       if (((desc->start ^ realAddress) & desc->select) == 0)
-        return desc;
+      {
+        /* sanity check - make sure the descriptor is large enough to hold the target address */
+        if (realAddress - desc->start < desc->len)
+          return desc;
+      }
     }
   }
 

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -259,6 +259,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     </ClCompile>
     <ClCompile Include="rcheevos\src\rhash\md5.c" />
     <ClCompile Include="speex\resample.c" />
+    <ClCompile Include="States.cpp" />
     <ClCompile Include="Util.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RALibretro.vcxproj.filters
+++ b/src/RALibretro.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="Memory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="States.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="About.h">

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -27,6 +27,9 @@ along with RALibRetro.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "RA_Interface.h"
 
+#include <jsonsax/jsonsax.h>
+#include <rcheevos/include/rconsoles.h>
+
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winuser.h>
@@ -45,42 +48,99 @@ bool States::init(Logger* logger, Config* config, Video* video)
   return true;
 }
 
-void States::setGame(const std::string& gameFileName, const std::string& coreName, libretro::Core* core)
+void States::setGame(const std::string& gameFileName, int system, const std::string& coreName, libretro::Core* core)
 {
   _gameFileName = gameFileName;
+  _system = system;
   _coreName = coreName;
   _core = core;
 }
 
-std::string States::getSRamPath()
+std::string States::buildPath(Path path) const
 {
-  std::string path = _config->getSaveDirectory();
-  path += _gameFileName;
-  path += ".sram";
-  return path;
+  std::string savePath;
+
+  if (path & Path::State)
+  {
+    savePath = _config->getRootFolder();
+    savePath += "States\\";
+  }
+  else
+  {
+    savePath = _config->getSaveDirectory();
+  }
+
+  if (path & Path::System)
+  {
+    savePath += rc_console_name(_system);
+    savePath += '\\';
+  }
+
+  if (path & Path::Core)
+  {
+    savePath += _core->getSystemInfo()->library_name;
+    savePath += '\\';
+  }
+
+  if (path & Path::Game)
+    savePath += util::fileName(_gameFileName) + "\\";
+
+  return savePath;
 }
 
-std::string States::getStatePath(unsigned ndx)
+std::string States::getSRamPath() const
 {
-  std::string path = _config->getSaveDirectory();
-  path += _gameFileName;
+  return getSRamPath(_sramPath);
+}
 
-  path += "-";
-  path += _coreName;
+std::string States::getSRamPath(Path path) const
+{
+  std::string sramPath = buildPath(path);
+
+  if (path == Path::Saves)
+    sramPath += _gameFileName;
+  else
+    sramPath += util::fileName(_gameFileName);
+
+  sramPath += ".sram";
+  return sramPath;
+}
+
+std::string States::getStatePath(unsigned ndx) const
+{
+  return getStatePath(ndx, _statePath);
+}
+
+std::string States::getStatePath(unsigned ndx, Path path) const
+{
+  std::string statePath = buildPath(path);
+
+  if (path == Path::Saves)
+    statePath += _gameFileName;
+  else
+    statePath += util::fileName(_gameFileName);
+
+  if (!(path & Path::Core))
+  {
+    statePath += "-";
+    statePath += _coreName;
+  }
   
-  char index[16];
+  char index[8];
   sprintf(index, ".%03u", ndx);
 
-  path += index;
-  path += ".state";
+  statePath += index;
+  statePath += ".state";
 
-  return path;
+  return statePath;
 }
 
 void States::saveState(const std::string& path)
 {
   _logger->info(TAG "Saving state to %s", path.c_str());
-  
+
+  util::ensureDirectoryExists(util::directory(path));
+
   size_t size = _core->serializeSize();
   void* data = malloc(size);
 
@@ -189,7 +249,212 @@ bool States::loadState(unsigned ndx)
 bool States::existsState(unsigned ndx)
 {
   std::string path = getStatePath(ndx);
-  struct stat statbuf;
+  return util::exists(path);
+}
 
-  return (stat(path.c_str(), &statbuf) == 0);
+const States::Path States::_savePaths[] =
+{
+  (States::Path)(States::Path::Saves),
+  (States::Path)(States::Path::Saves | States::Path::Core),
+  (States::Path)(States::Path::Saves | States::Path::Core | States::Path::Game),
+  (States::Path)(States::Path::Saves | States::Path::System),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Game),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Core),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Core | States::Path::Game),
+};
+
+const States::Path States::_statePaths[] =
+{
+  (States::Path)(States::Path::Saves),
+  (States::Path)(States::Path::Saves | States::Path::Core),
+  (States::Path)(States::Path::Saves | States::Path::Core | States::Path::Game),
+  (States::Path)(States::Path::Saves | States::Path::System),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Game),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Core),
+  (States::Path)(States::Path::Saves | States::Path::System | States::Path::Core | States::Path::Game),
+  (States::Path)(States::Path::State),
+  (States::Path)(States::Path::State | States::Path::Core),
+  (States::Path)(States::Path::State | States::Path::Core | States::Path::Game),
+  (States::Path)(States::Path::State | States::Path::System),
+  (States::Path)(States::Path::State | States::Path::System | States::Path::Game),
+  (States::Path)(States::Path::State | States::Path::System | States::Path::Core),
+  (States::Path)(States::Path::State | States::Path::System | States::Path::Core | States::Path::Game),
+};
+
+extern HWND g_mainWindow;
+
+void States::migrateFiles()
+{
+  Path testPath;
+
+  // if the sram file exists, don't move anything
+  std::string sramPath = getSRamPath();
+  if (!util::exists(sramPath))
+  {
+    testPath = _sramPath;
+    for (int i = 0; i < sizeof(_savePaths) / sizeof(_savePaths[0]); ++i)
+    {
+      std::string path = getSRamPath(_savePaths[i]);
+      if (util::exists(path))
+      {
+        testPath = (Path)i;
+        break;
+      }
+    }
+
+    if (testPath != _sramPath)
+    {
+      std::string oldPath = buildPath(testPath);
+      std::string newPath = buildPath(_sramPath);
+      const size_t rootFolderLength = strlen(_config->getRootFolder());
+      oldPath.erase(0, rootFolderLength);
+      newPath.erase(0, rootFolderLength);
+
+      std::string message = "Found SRAM data in " + oldPath + ".\n\nMove to " + newPath + "?";
+      if (MessageBox(g_mainWindow, message.c_str(), "RALibRetro", MB_YESNO) == IDYES)
+      {
+        util::ensureDirectoryExists(util::directory(sramPath));
+
+        MoveFile(getSRamPath(testPath).c_str(), sramPath.c_str());
+      }
+    }
+  }
+
+  for (unsigned ndx = 1; ndx <= 10; ndx++)
+  {
+    std::string statePath = getStatePath(ndx, _statePath);
+    if (util::exists(statePath))
+      return;
+  }
+
+  testPath = _statePath;
+  for (unsigned ndx = 1; ndx <= 10; ndx++)
+  {
+    for (int i = 0; i < sizeof(_statePaths) / sizeof(_statePaths[0]); ++i)
+    {
+      std::string statePath = getStatePath(ndx, _statePaths[i]);
+      if (util::exists(statePath))
+      {
+        testPath = _statePaths[i];
+        break;
+      }
+    }
+
+    if (testPath != _statePath)
+    {
+      std::string oldPath = buildPath(testPath);
+      std::string newPath = buildPath(_statePath);
+      const size_t rootFolderLength = strlen(_config->getRootFolder());
+      oldPath.erase(0, rootFolderLength);
+      newPath.erase(0, rootFolderLength);
+
+      std::string message = "Found save state data in " + oldPath + ".\n\nMove to " + newPath + "?";
+      if (MessageBox(g_mainWindow, message.c_str(), "RALibRetro", MB_YESNO) == IDYES)
+      {
+        util::ensureDirectoryExists(util::directory(getStatePath(1, _statePath)));
+
+        for (unsigned ndx = 1; ndx <= 10; ndx++)
+        {
+          oldPath = getStatePath(ndx, testPath);
+          newPath = getStatePath(ndx, _statePath);
+          if (util::exists(oldPath))
+          {
+            auto res = MoveFile(oldPath.c_str(), newPath.c_str());
+
+            std::string oldRap = oldPath + ".rap";
+            std::string newRap = newPath + ".rap";
+            MoveFile(oldRap.c_str(), newRap.c_str());
+
+            std::string oldPng = oldPath + ".png";
+            std::string newPng = newPath + ".png";
+            MoveFile(oldPng.c_str(), newPng.c_str());
+          }
+        }
+      }
+
+      break;
+    }
+  }
+}
+
+std::string States::encodePath(Path path)
+{
+  std::string settings;
+
+  settings += (path & Path::State) ? 'T' : 'S';
+  if (path & Path::System)
+    settings += 'Y';
+  if (path & Path::Core)
+    settings += 'C';
+  if (path & Path::Game)
+    settings += 'G';
+
+  return settings;
+}
+
+std::string States::serializeSettings() const
+{
+  std::string settings = "{";
+
+  settings += "\"sramPath\":\"";
+  settings += encodePath(_sramPath);
+  settings += "\",";
+
+  settings += "\"statePath\":\"";
+  settings += encodePath(_statePath);
+  settings += "\"";
+
+  settings += "}";
+  return settings;
+}
+
+States::Path States::decodePath(const std::string& shorthand)
+{
+  int path = 0;
+  for (auto c : shorthand)
+  {
+    switch (c)
+    {
+      case 'S': path |= (int)Path::Saves; break;
+      case 'T': path |= (int)Path::State; break;
+      case 'Y': path |= (int)Path::System; break;
+      case 'C': path |= (int)Path::Core; break;
+      case 'G': path |= (int)Path::Game; break;
+      default: break;
+    }
+  }
+
+  return (States::Path)path;
+}
+
+bool States::deserializeSettings(const char* json)
+{
+  struct Deserialize
+  {
+    States* self;
+    std::string key;
+  };
+  Deserialize ud;
+  ud.self = this;
+
+  jsonsax_result_t res = jsonsax_parse((char*)json, &ud, [](void* udata, jsonsax_event_t event, const char* str, size_t num)
+  {
+    auto* ud = (Deserialize*)udata;
+
+    if (event == JSONSAX_KEY)
+    {
+      ud->key = std::string(str, num);
+    }
+    else if (event == JSONSAX_STRING)
+    {
+      if (ud->key == "sramPath")
+        ud->self->_sramPath = decodePath(std::string(str, num));
+      else if (ud->key == "statePath")
+        ud->self->_statePath = decodePath(std::string(str, num));
+    }
+
+    return 0;
+  });
+
+  return (res == JSONSAX_OK);
 }

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -1,0 +1,195 @@
+/*
+Copyright (C) 2018 Andre Leiradella
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with RALibRetro.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "States.h"
+
+#include "Util.h"
+
+#include "libretro/Core.h"
+
+#include "resource.h"
+
+#include "RA_Interface.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winuser.h>
+#include <commdlg.h>
+#include <shlobj.h>
+
+#define TAG "[SAV] "
+
+bool States::init(Logger* logger, Config* config, Video* video)
+{
+  _logger = logger;
+  _config = config;
+  _video = video;
+  _core = NULL;
+
+  return true;
+}
+
+void States::setGame(const std::string& gameFileName, const std::string& coreName, libretro::Core* core)
+{
+  _gameFileName = gameFileName;
+  _coreName = coreName;
+  _core = core;
+}
+
+std::string States::getSRamPath()
+{
+  std::string path = _config->getSaveDirectory();
+  path += _gameFileName;
+  path += ".sram";
+  return path;
+}
+
+std::string States::getStatePath(unsigned ndx)
+{
+  std::string path = _config->getSaveDirectory();
+  path += _gameFileName;
+
+  path += "-";
+  path += _coreName;
+  
+  char index[16];
+  sprintf(index, ".%03u", ndx);
+
+  path += index;
+  path += ".state";
+
+  return path;
+}
+
+void States::saveState(const std::string& path)
+{
+  _logger->info(TAG "Saving state to %s", path.c_str());
+  
+  size_t size = _core->serializeSize();
+  void* data = malloc(size);
+
+  if (data == NULL)
+  {
+    _logger->error(TAG "Out of memory allocating %lu bytes for the game state", size);
+    return;
+  }
+
+  if (!_core->serialize(data, size))
+  {
+    free(data);
+    return;
+  }
+
+  unsigned width, height, pitch;
+  enum retro_pixel_format format;
+  const void* pixels = _video->getFramebuffer(&width, &height, &pitch, &format);
+
+  if (pixels == NULL)
+  {
+    free(data);
+    return;
+  }
+
+  if (!util::saveFile(_logger, path.c_str(), data, size))
+  {
+    free((void*)pixels);
+    free(data);
+    return;
+  }
+
+  util::saveImage(_logger, path + ".png", pixels, width, height, pitch, format);
+  RA_OnSaveState(path.c_str());
+
+  free((void*)pixels);
+  free(data);
+}
+
+void States::saveState(unsigned ndx)
+{
+  saveState(getStatePath(ndx));
+}
+
+bool States::loadState(const std::string& path)
+{
+  if (!RA_WarnDisableHardcore("load a state"))
+  {
+    _logger->warn(TAG "Hardcore mode is active, can't load state");
+    return false;
+  }
+
+  size_t size;
+  void* data = util::loadFile(_logger, path.c_str(), &size);
+
+  if (data == NULL)
+  {
+    return false;
+  }
+
+  _core->unserialize(data, size);
+  free(data);
+  RA_OnLoadState(path.c_str());
+
+  unsigned width, height, pitch;
+  enum retro_pixel_format format;
+  _video->getFramebufferSize(&width, &height, &format);
+
+  unsigned image_width, image_height;
+  const void* pixels = util::loadImage(_logger, path + ".png", &image_width, &image_height, &pitch);
+  if (pixels == NULL)
+  {
+    _logger->error(TAG "Error loading savestate screenshot");
+    return true; /* state was still loaded even if the frame buffer wasn't updated */
+  }
+
+  /* if the widths aren't the same, the stride differs and we can't just load the pixels */
+  if (image_width == width)
+  {
+    void* converted = util::fromRgb(_logger, pixels, image_width, image_height, &pitch, format);
+    if (converted == NULL)
+    {
+      _logger->error(TAG "Error converting savestate screenshot to the framebuffer format");
+    }
+    else
+    {
+      /* prevent frame buffer corruption */
+      if (height > image_height)
+        height = image_height;
+
+      _video->setFramebuffer(converted, width, height, pitch);
+
+      free((void*)converted);
+    }
+  }
+
+  free((void*)pixels);
+  return true;
+}
+
+bool States::loadState(unsigned ndx)
+{
+  return loadState(getStatePath(ndx));
+}
+
+bool States::existsState(unsigned ndx)
+{
+  std::string path = getStatePath(ndx);
+  struct stat statbuf;
+
+  return (stat(path.c_str(), &statbuf) == 0);
+}

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -289,7 +289,7 @@ void States::migrateFiles()
   if (!util::exists(sramPath))
   {
     testPath = _sramPath;
-    for (int i = 0; i < sizeof(_sramPaths) / sizeof(_sramPaths[0]); ++i)
+    for (unsigned i = 0; i < sizeof(_sramPaths) / sizeof(_sramPaths[0]); ++i)
     {
       std::string path = getSRamPath(_sramPaths[i]);
       if (util::exists(path))
@@ -325,7 +325,7 @@ void States::migrateFiles()
   }
 
   testPath = _statePath;
-  for (int i = 0; i < sizeof(_statePaths) / sizeof(_statePaths[0]); ++i)
+  for (unsigned i = 0; i < sizeof(_statePaths) / sizeof(_statePaths[0]); ++i)
   {
     std::string statePath = buildPath(_statePaths[i]);
     if (!util::exists(statePath))
@@ -360,7 +360,7 @@ void States::migrateFiles()
           newPath = getStatePath(ndx, _statePath);
           if (util::exists(oldPath))
           {
-            auto res = MoveFile(oldPath.c_str(), newPath.c_str());
+            MoveFile(oldPath.c_str(), newPath.c_str());
 
             std::string oldRap = oldPath + ".rap";
             std::string newRap = newPath + ".rap";
@@ -466,7 +466,7 @@ class StatesPathAccessor : public States
 public:
   int getSramPathOption(int index)
   {
-    if (index >= sizeof(_sramPaths) / sizeof(_sramPaths[0]))
+    if ((unsigned)index >= sizeof(_sramPaths) / sizeof(_sramPaths[0]))
       return -1;
 
     return _sramPaths[index];
@@ -474,7 +474,7 @@ public:
 
   int getStatePathOption(int index)
   {
-    if (index >= sizeof(_statePaths) / sizeof(_statePaths[0]))
+    if ((unsigned)index >= sizeof(_statePaths) / sizeof(_statePaths[0]))
       return -1;
 
     return _statePaths[index];
@@ -539,7 +539,7 @@ void States::showDialog()
   WORD y = 0;
 
   int sramPath = 0;
-  for (int i = 0; i < sizeof(_sramPaths) / sizeof(_sramPaths[0]); ++i)
+  for (unsigned i = 0; i < sizeof(_sramPaths) / sizeof(_sramPaths[0]); ++i)
   {
     if (_sramPaths[i] == _sramPath)
     {
@@ -552,7 +552,7 @@ void States::showDialog()
   y += LINE;
 
   int statePath = 0;
-  for (int i = 0; i < sizeof(_statePaths) / sizeof(_statePaths[0]); ++i)
+  for (unsigned i = 0; i < sizeof(_statePaths) / sizeof(_statePaths[0]); ++i)
   {
     if (_statePaths[i] == _statePath)
     {

--- a/src/States.h
+++ b/src/States.h
@@ -1,0 +1,53 @@
+/*
+Copyright (C) 2018 Andre Leiradella
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with RALibRetro.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "components/Config.h"
+#include "components/Logger.h"
+#include "components/Video.h"
+
+#include "libretro/Core.h"
+
+class States
+{
+public:
+  bool init(Logger* logger, Config* config, Video* video);
+
+  void setGame(const std::string& gameFileName, const std::string& coreName, libretro::Core* core);
+
+  std::string getSRamPath();
+  std::string getStatePath(unsigned ndx);
+
+  void        saveState(const std::string& path);
+  void        saveState(unsigned ndx);
+  bool        loadState(const std::string& path);
+  bool        loadState(unsigned ndx);
+
+  bool        existsState(unsigned ndx);
+
+protected:
+  Logger* _logger;
+  Config* _config;
+  Video* _video;
+
+  std::string _gameFileName;
+  std::string _coreName;
+  libretro::Core* _core;
+};

--- a/src/States.h
+++ b/src/States.h
@@ -46,6 +46,8 @@ public:
   std::string serializeSettings() const;
   bool        deserializeSettings(const char* json);
 
+  void        showDialog();
+
 protected:
   enum Path
   {
@@ -57,6 +59,9 @@ protected:
   };
   Path _sramPath = Path::Saves;
   Path _statePath = Path::Saves;
+
+  static const States::Path States::_sramPaths[];
+  static const States::Path States::_statePaths[];
 
   Logger* _logger;
   Config* _config;
@@ -74,7 +79,4 @@ private:
 
   std::string getSRamPath(Path path) const;
   std::string getStatePath(unsigned ndx, Path path) const;
-
-  static const States::Path States::_savePaths[];
-  static const States::Path States::_statePaths[];
 };

--- a/src/States.h
+++ b/src/States.h
@@ -30,24 +30,51 @@ class States
 public:
   bool init(Logger* logger, Config* config, Video* video);
 
-  void setGame(const std::string& gameFileName, const std::string& coreName, libretro::Core* core);
+  void setGame(const std::string& gameFileName, int system, const std::string& coreName, libretro::Core* core);
 
-  std::string getSRamPath();
-  std::string getStatePath(unsigned ndx);
+  std::string getSRamPath() const;
+  std::string getStatePath(unsigned ndx) const;
 
   void        saveState(const std::string& path);
   void        saveState(unsigned ndx);
   bool        loadState(const std::string& path);
   bool        loadState(unsigned ndx);
 
+  void        migrateFiles();
   bool        existsState(unsigned ndx);
 
+  std::string serializeSettings() const;
+  bool        deserializeSettings(const char* json);
+
 protected:
+  enum Path
+  {
+    Saves = 0x00,
+    State = 0x01,
+    System = 0x02,
+    Core = 0x04,
+    Game = 0x08
+  };
+  Path _sramPath = Path::Saves;
+  Path _statePath = Path::Saves;
+
   Logger* _logger;
   Config* _config;
   Video* _video;
 
   std::string _gameFileName;
+  int _system;
   std::string _coreName;
   libretro::Core* _core;
+
+private:
+  std::string buildPath(Path path) const;
+  static std::string encodePath(Path path);
+  static Path decodePath(const std::string& shorthand);
+
+  std::string getSRamPath(Path path) const;
+  std::string getStatePath(unsigned ndx, Path path) const;
+
+  static const States::Path States::_savePaths[];
+  static const States::Path States::_statePaths[];
 };

--- a/src/States.h
+++ b/src/States.h
@@ -60,8 +60,8 @@ protected:
   Path _sramPath = Path::Saves;
   Path _statePath = Path::Saves;
 
-  static const States::Path States::_sramPaths[];
-  static const States::Path States::_statePaths[];
+  static const States::Path _sramPaths[];
+  static const States::Path _statePaths[];
 
   Logger* _logger;
   Config* _config;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -84,6 +84,11 @@ time_t util::fileTime(const std::string& path)
   }
 }
 
+bool util::exists(const std::string& path)
+{
+  return util::fileTime(path) != 0;
+}
+
 FILE* util::openFile(Logger* logger, const std::string& path, const char* mode)
 {
   FILE* file;
@@ -543,6 +548,29 @@ std::string util::replaceFileName(const std::string& originalPath, const char* n
 
   newPath.replace(newPath.begin() + ndx + 1, newPath.end(), newFileName);
   return newPath;
+}
+
+std::string util::directory(const std::string& path)
+{
+  std::string newPath = path;
+#ifdef _WIN32
+  const auto ndx = newPath.find_last_of('\\');
+#else
+  const auto ndx = newPath.find_last_of('/');
+#endif
+  if (ndx != std::string::npos)
+    newPath.erase(ndx, path.length() - ndx);
+
+  return newPath;
+}
+
+void util::ensureDirectoryExists(const std::string& directory)
+{
+  if (!util::exists(directory))
+  {
+    /* warning: this requires a full path */
+    SHCreateDirectoryEx(NULL, directory.c_str(), NULL);
+  }
 }
 
 #ifdef _WINDOWS

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -564,6 +564,7 @@ std::string util::directory(const std::string& path)
   return newPath;
 }
 
+#ifdef _WINDOWS
 void util::ensureDirectoryExists(const std::string& directory)
 {
   if (!util::exists(directory))
@@ -572,6 +573,7 @@ void util::ensureDirectoryExists(const std::string& directory)
     SHCreateDirectoryEx(NULL, directory.c_str(), NULL);
   }
 }
+#endif
 
 #ifdef _WINDOWS
 std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)

--- a/src/Util.h
+++ b/src/Util.h
@@ -41,6 +41,8 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 namespace util
 {
   time_t      fileTime(const std::string& path);
+  bool        exists(const std::string& path);
+
   FILE*       openFile(Logger* logger, const std::string& path, const char* mode);
   std::string loadFile(Logger* logger, const std::string& path);
   void*       loadFile(Logger* logger, const std::string& path, size_t* size);
@@ -64,6 +66,9 @@ namespace util
   std::string fileNameWithExtension(const std::string& path);
   std::string extension(const std::string& path);
   std::string replaceFileName(const std::string& originalPath, const char* newFileName);
+
+  std::string directory(const std::string& path);
+  void        ensureDirectoryExists(const std::string& path);
 
 #ifdef _WINDOWS
   std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter);

--- a/src/Util.h
+++ b/src/Util.h
@@ -68,7 +68,10 @@ namespace util
   std::string replaceFileName(const std::string& originalPath, const char* newFileName);
 
   std::string directory(const std::string& path);
+
+#ifdef _WINDOWS
   void        ensureDirectoryExists(const std::string& path);
+#endif
 
 #ifdef _WINDOWS
   std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter);

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -43,6 +43,8 @@ public:
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
+  void setSaveDirectory(const std::string& path) { _saveFolder = path; }
+
   const char* getRootFolder()
   {
     return _rootFolder.c_str();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ void loadROM(const char* path)
 
 int main(int argc, char* argv[])
 {
-  bool ok = app.init("RALibretro", 640, 480);
+  bool ok = app.init("RALibRetro", 640, 480);
 
   if (ok)
   {

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -107,6 +107,7 @@ main MENU
             MENUITEM "Controller 1...", IDM_INPUT_CONTROLLER_1
             MENUITEM "Controller 2...", IDM_INPUT_CONTROLLER_2
         }
+        MENUITEM "Saving...", IDM_SAVING_CONFIG
         MENUITEM "Video...", IDM_VIDEO_CONFIG
         POPUP "Window Size"
         {

--- a/src/resource.h
+++ b/src/resource.h
@@ -87,3 +87,4 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #define IDM_INPUT_CONTROLLER_1                  40014
 #define IDM_INPUT_CONTROLLER_2                  40015
 #define IDM_MANAGE_CORES                        40016
+#define IDM_SAVING_CONFIG                       40017


### PR DESCRIPTION
Adds a new "Saving Settings" dialog that allows the user to specify if they want to put their SRAM and save state files into subfolders for the current system, core, or game.
![image](https://user-images.githubusercontent.com/32680403/84458334-091d4480-ac22-11ea-9307-8dc671e93f78.png)

The default setting for both is "Saves", which mimics the existing behavior. 

When an existing game is loaded after the settings have been changed, we attempt to detect the files in the old location and prompt the user to move them.
![image](https://user-images.githubusercontent.com/32680403/84458462-4c77b300-ac22-11ea-9053-aadebd8bd03c.png)

Note: this only detects and moves files managed by RALibRetro. Additional files generated by the core have to be moved manually.