### PR TITLE
show error when trying to update/delete loaded core

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2228,7 +2228,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       break;
 
     case IDM_MANAGE_CORES:
-      if (showCoresDialog(&_config, &_logger))
+      if (showCoresDialog(&_config, &_logger, _coreName))
         buildSystemsMenu();
       break;
 

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -298,6 +298,7 @@ public:
   std::vector<std::string> coreNames;
   Config* config;
   Logger* logger;
+  const std::string* loadedCore;
   bool modified = false;
 
 protected:
@@ -492,10 +493,22 @@ protected:
         {
           if (cmd >= 51400)
           {
+            if (coreNames[cmd - 51400] == *loadedCore)
+            {
+              MessageBox(hwnd, "Cannot delete active core", "Error", MB_OK);
+              return 0;
+            }
+
             deleteCore(hwnd, coreNames[cmd - 51400]);
           }
           else
           {
+            if (coreNames[cmd - 51300] == *loadedCore)
+            {
+              MessageBox(hwnd, "Cannot update active core", "Error", MB_OK);
+              return 0;
+            }
+
             HWND hUpdate = GetDlgItem(hwnd, cmd);
             SetWindowText(hUpdate, "Downloading...");
             EnableWindow(hwnd, FALSE);
@@ -573,12 +586,13 @@ static void getCoreSystemTimes(Config* config, Logger* logger)
   }
 }
 
-bool showCoresDialog(Config* config, Logger* logger)
+bool showCoresDialog(Config* config, Logger* logger, const std::string& loadedCore)
 {
   CoreDialog db;
   db.init("Manage Cores");
   db.config = config;
   db.logger = logger;
+  db.loadedCore = &loadedCore;
 
   getCoreSystemTimes(config, logger);
 

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -38,4 +38,4 @@ int    encodeCoreName(const std::string& coreName, int system);
 const std::string& getCoreName(int encoded, int& systemOut);
 const std::string* getCoreDeprecationMessage(const std::string& coreName);
 
-bool   showCoresDialog(Config* config, Logger* logger);
+bool   showCoresDialog(Config* config, Logger* logger, const std::string& loadedCoreName);


### PR DESCRIPTION
The dll is held open when it's in use, so it's impossible to delete or update it. If the user tries to update, they get a generic "cannot unzip" error. If they try to delete it, it acts like it worked, but nothing actually happened.

This changes the behavior such that the user is informed that the core is active when they try to do either, and does not attempt to perform the action.