### PR TITLE
convert relative paths to absolute paths before hashing in RAHasher

### DIFF
--- a/src/RAHasher.cpp
+++ b/src/RAHasher.cpp
@@ -102,8 +102,10 @@ int main(int argc, char* argv[])
     file = argv[3];
   }
 
-  if (system != 0 && !file.empty())
+  if (consoleId != 0 && !file.empty())
   {
+    file = util::fullPath(file);
+
     logger.reset(new StdErrLogger);
 
     rc_hash_init_error_message_callback(rhash_log_error);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -500,6 +500,28 @@ std::string util::jsonUnescape(const std::string& str)
   return res;
 }
 
+std::string util::fullPath(const std::string& path)
+{
+#ifdef _WIN32
+ #ifdef _WINDOWS
+  std::wstring unicodePath = util::utf8ToUChar(path);
+  wchar_t fullPath[_MAX_PATH];
+  if (_wfullpath(fullPath, unicodePath.c_str(), sizeof(fullPath) / sizeof(fullPath[0])))
+    return util::ucharToUtf8(std::wstring(fullPath));
+ #else
+  char fullPath[_MAX_PATH];
+  if (_fullpath(fullPath, path.c_str(), sizeof(fullPath) / sizeof(fullPath[0])))
+    return std::string(fullPath);
+ #endif
+#else
+  char fullPath[PATH_MAX];
+  if (realpath(path.c_str(), fullPath))
+    return std::string(fullPath);
+#endif
+
+  return path;
+}
+
 std::string util::fileNameWithExtension(const std::string& path)
 {
   const char* str = path.c_str();

--- a/src/Util.h
+++ b/src/Util.h
@@ -60,6 +60,7 @@ namespace util
   std::string jsonEscape(const std::string& str);
   std::string jsonUnescape(const std::string& str);
 
+  std::string fullPath(const std::string& path);
   std::string fileName(const std::string& path);
   std::string fileNameWithExtension(const std::string& path);
   std::string extension(const std::string& path);


### PR DESCRIPTION
Addresses comment here: https://github.com/RetroAchievements/rcheevos/pull/72#issuecomment-637764884
> the one caveat to this is that hashing the file from within the directory won't see the subdirectory.