### PR TITLE
allow core to provide labels for config options

### DIFF
--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -40,6 +40,7 @@ public:
   virtual const char* getSystemPath() override;
 
   virtual void setVariables(const struct retro_variable* variables, unsigned count) override;
+  virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) override;
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
@@ -70,6 +71,7 @@ protected:
     int         _selected;
 
     std::vector<std::string> _options;
+    std::vector<std::string> _labels;
   };
 
   static void initializeControllerVariable(Variable& variable, const char* name, const char* key, const std::map<std::string, unsigned>& names, unsigned selectedDevice);

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -113,6 +113,7 @@ namespace libretro
     virtual const char* getSystemPath() = 0;
 
     virtual void setVariables(const struct retro_variable* variables, unsigned count) = 0;
+    virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) = 0;
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;
   };

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -74,12 +74,6 @@ namespace libretro
       return _inputDescriptors;
     }
 
-    inline const struct retro_variable* getVariables(unsigned* count) const
-    {
-      *count = _variablesCount;
-      return _variables;
-    }
-
     inline const struct retro_subsystem_info* getSubsystemInfo(unsigned* count) const
     {
       *count = _subsystemInfoCount;
@@ -170,6 +164,9 @@ namespace libretro
     bool getHWRenderInterface(const struct retro_hw_render_interface** data) const;
     bool setSupportAchievements(bool data);
     bool getInputBitmasks(bool* data);
+    bool getCoreOptionsVersion(unsigned* data) const;
+    bool setCoreOptions(const struct retro_core_option_definition* data);
+    bool setCoreOptionsIntl(const struct retro_core_options_intl* data);
 
     // Callbacks
     bool                 environmentCallback(unsigned cmd, void* data);
@@ -215,10 +212,7 @@ namespace libretro
     
     unsigned                        _inputDescriptorsCount;
     struct retro_input_descriptor*  _inputDescriptors;
-    
-    unsigned                        _variablesCount;
-    struct retro_variable*          _variables;
-    
+
     struct retro_hw_render_callback _hardwareRenderCallback;
     bool                            _needsHardwareRender;
     


### PR DESCRIPTION
Implements the `RETRO_ENVIRONMENT_SET_CORE_OPTIONS` environment callback so cores can provide user-friendly labels for their options.

Here's the Beetle PSX settings dialog before and after:
![image](https://user-images.githubusercontent.com/32680403/84584808-268b1380-adc6-11ea-82af-ff7728b81a71.png)

![image](https://user-images.githubusercontent.com/32680403/84584812-29860400-adc6-11ea-8ae5-9b6d02a0de13.png)

Most of the changes are whitespace and capitalization, but I've highlighted the CPU Dynarec field where you can see the options are (hopefully) clearer now.