### PR TITLE
implement RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY

### DIFF
--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -41,6 +41,7 @@ public:
 
   virtual void setVariables(const struct retro_variable* variables, unsigned count) override;
   virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) override;
+  virtual void setVariableDisplay(const struct retro_core_option_display* display) override;
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
@@ -71,6 +72,7 @@ protected:
     std::string _key;
     std::string _name;
     int         _selected;
+    bool        _hidden;
 
     std::vector<std::string> _options;
     std::vector<std::string> _labels;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -114,6 +114,7 @@ namespace libretro
 
     virtual void setVariables(const struct retro_variable* variables, unsigned count) = 0;
     virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) = 0;
+    virtual void setVariableDisplay(const struct retro_core_option_display* display) = 0;
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;
   };

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -104,6 +104,11 @@ namespace
       (void)count;
     }
 
+    virtual void setVariableDisplay(const struct retro_core_option_display* display) override
+    {
+      (void)display;
+    }
+
     virtual bool varUpdated() override
     {
       return false;
@@ -1201,6 +1206,12 @@ bool libretro::Core::setCoreOptionsIntl(const struct retro_core_options_intl* da
   return setCoreOptions(data->us);
 }
 
+bool libretro::Core::setCoreOptionsDisplay(const struct retro_core_option_display* data)
+{
+  _config->setVariableDisplay(data);
+  return true;
+}
+
 static void getEnvName(char* name, size_t size, unsigned cmd)
 {
   static const char* names[] =
@@ -1410,6 +1421,10 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
 
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL:
     ret = setCoreOptionsIntl((const struct retro_core_options_intl*)data);
+    break;
+
+  case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY:
+    ret = setCoreOptionsDisplay((const struct retro_core_option_display*)data);
     break;
 
   default:

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -155,6 +155,7 @@ namespace libretro
     bool getCoreOptionsVersion(unsigned* data) const;
     bool setCoreOptions(const struct retro_core_option_definition* data);
     bool setCoreOptionsIntl(const struct retro_core_options_intl* data);
+    bool setCoreOptionsDisplay(const struct retro_core_option_display* data);
 
     // Callbacks
     bool                 environmentCallback(unsigned cmd, void* data);


### PR DESCRIPTION
Allows the core to specify that it wants to hide specific options. The most obvious use of this is the beetle PSX core hiding PAL options for NTSC games and vice versa.