### PR TITLE
allow user to specify interval for flushing SRAM to disk

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -89,7 +89,6 @@ protected:
   void        enableSlots();
   void        enableRecent();
   void        updateCDMenu(const char names[][128], int count, bool updateLabels);
-  std::string getSRamPath();
   std::string getStatePath(unsigned ndx);
   std::string getConfigPath();
   std::string getCoreConfigPath(const std::string& coreName);

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -80,13 +80,13 @@ std::string States::buildPath(Path path) const
 
   if ((path & Path::System) && _system)
   {
-    savePath += rc_console_name(_system);
+    savePath += util::sanitizeFileName(rc_console_name(_system));
     savePath += '\\';
   }
 
   if ((path & Path::Core) && _core->getSystemInfo()->library_name)
   {
-    savePath += _core->getSystemInfo()->library_name;
+    savePath += util::sanitizeFileName(_core->getSystemInfo()->library_name);
     savePath += '\\';
   }
 

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -36,6 +36,8 @@ along with RALibRetro.  If not, see <http://www.gnu.org/licenses/>.
 #include <commdlg.h>
 #include <shlobj.h>
 
+#include <time.h>
+
 #define TAG "[SAV] "
 
 extern HWND g_mainWindow;
@@ -46,6 +48,7 @@ bool States::init(Logger* logger, Config* config, Video* video)
   _config = config;
   _video = video;
   _core = NULL;
+  _lastSave = 0;
 
   return true;
 }
@@ -58,6 +61,12 @@ void States::setGame(const std::string& gameFileName, int system, const std::str
   _core = core;
 
   _config->setSaveDirectory(buildPath(_sramPath));
+
+  if (_lastSaveData != NULL)
+  {
+    free(_lastSaveData);
+    _lastSaveData = NULL;
+  }
 }
 
 std::string States::buildPath(Path path) const
@@ -251,6 +260,17 @@ bool States::existsState(unsigned ndx)
   return util::exists(path);
 }
 
+const int States::_saveIntervals[] =
+{
+  0,
+  10,
+  30,
+  60,
+  120,
+  300,
+  600
+};
+
 const States::Path States::_sramPaths[] =
 {
   (States::Path)(States::Path::Saves),
@@ -279,6 +299,78 @@ const States::Path States::_statePaths[] =
   (States::Path)(States::Path::State | States::Path::System | States::Path::Core),
   (States::Path)(States::Path::State | States::Path::System | States::Path::Core | States::Path::Game),
 };
+
+void States::loadSRAM(libretro::Core* core)
+{
+  const size_t sramSize = core->getMemorySize(RETRO_MEMORY_SAVE_RAM);
+  if (sramSize != 0)
+  {
+    std::string sramPath = getSRamPath();
+    size_t fileSize;
+
+    void* data = util::loadFile(_logger, sramPath, &fileSize);
+    if (data != NULL)
+    {
+      if (fileSize == sramSize)
+      {
+        void* memory = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
+        memcpy(memory, data, sramSize);
+        _logger->info(TAG "Loaded %lu bytes of Save RAM from disk", fileSize);
+      }
+      else
+      {
+        _logger->error(TAG "Save RAM size mismatch, wanted %lu, got %lu from disk", sramSize, fileSize);
+      }
+
+      if (_saveInterval > 0)
+        _lastSaveData = data;
+      else
+        free(data);
+    }
+  }
+
+  _lastSave = time(NULL);
+}
+
+void States::saveSRAM(libretro::Core* core)
+{
+  size_t sramSize = core->getMemorySize(RETRO_MEMORY_SAVE_RAM);
+  if (sramSize != 0)
+  {
+    void* data = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
+    std::string sramPath = getSRamPath();
+    util::saveFile(_logger, sramPath, data, sramSize);
+  }
+}
+
+void States::periodicSaveSRAM(libretro::Core* core)
+{
+  if (_saveInterval == 0)
+    return;
+
+  time_t now = time(NULL);
+  if (now - _lastSave >= _saveInterval)
+  {
+    size_t sramSize = core->getMemorySize(RETRO_MEMORY_SAVE_RAM);
+    if (sramSize != 0)
+    {
+      void* data = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
+      if (_lastSaveData == NULL || memcmp(data, _lastSaveData, sramSize) != 0)
+      {
+        if (_lastSaveData == NULL)
+          _lastSaveData = malloc(sramSize);
+
+        memcpy(_lastSaveData, data, sramSize);
+
+        // TODO: offload this to a background thread?
+        std::string sramPath = getSRamPath();
+        util::saveFile(_logger, sramPath, _lastSaveData, sramSize);
+      }
+    }
+
+    _lastSave = now;
+  }
+}
 
 void States::migrateFiles()
 {
@@ -397,6 +489,10 @@ std::string States::serializeSettings() const
 {
   std::string settings = "{";
 
+  settings += "\"saveInterval\":";
+  settings += std::to_string(_saveInterval);
+  settings += ",";
+
   settings += "\"sramPath\":\"";
   settings += encodePath(_sramPath);
   settings += "\",";
@@ -453,6 +549,11 @@ bool States::deserializeSettings(const char* json)
       else if (ud->key == "statePath")
         ud->self->_statePath = decodePath(std::string(str, num));
     }
+    else if (event == JSONSAX_NUMBER)
+    {
+      if (ud->key == "saveInterval")
+        ud->self->_saveInterval = (int)strtoul(str, NULL, 10);
+    }
 
     return 0;
   });
@@ -464,6 +565,40 @@ bool States::deserializeSettings(const char* json)
 class StatesPathAccessor : public States
 {
 public:
+  StatesPathAccessor()
+  {
+    if (_pathOptions[0].empty())
+    {
+      for (unsigned i = 0; i < sizeof(_pathOptions) / sizeof(_pathOptions[0]); ++i)
+      {
+        std::string& option = _pathOptions[i];
+        if (i & States::Path::State)
+          option = "States";
+        else
+          option = "Saves";
+
+        if (i & States::Path::System)
+          option += "\\[System]";
+        if (i & States::Path::Core)
+          option += "\\[Core]";
+        if (i & States::Path::Game)
+          option += "\\[Game]";
+      }
+
+      _intervalOptions[0] = "None";
+      for (unsigned i = 1; i < sizeof(_saveIntervals) / sizeof(_saveIntervals[0]); ++i)
+      {
+        int seconds = _saveIntervals[i];
+        if (seconds == 60)
+          _intervalOptions[i] = "1 minute";
+        else if ((seconds % 60) == 0)
+          _intervalOptions[i] = std::to_string(seconds / 60) + " minutes";
+        else
+          _intervalOptions[i] = std::to_string(seconds) + " seconds";
+      }
+    }
+  }
+
   int getSramPathOption(int index)
   {
     if ((unsigned)index >= sizeof(_sramPaths) / sizeof(_sramPaths[0]))
@@ -479,9 +614,27 @@ public:
 
     return _statePaths[index];
   }
+
+  const char* getPathOption(int option) const
+  {
+    return _pathOptions[option].c_str();
+  }
+
+  const char* getIntervalOption(int option) const
+  {
+    if (option < 0 || option >= sizeof(_saveIntervals) / sizeof(_saveIntervals[0]))
+      return NULL;
+
+    return _intervalOptions[option].c_str();
+  }
+
+private:
+  static std::string _pathOptions[16];
+  static std::string _intervalOptions[sizeof(_saveIntervals) / sizeof(_saveIntervals[0])];
 };
 
-static std::string s_pathOptions[16];
+std::string StatesPathAccessor::_pathOptions[];
+std::string StatesPathAccessor::_intervalOptions[];
 
 const char* s_getSramPathOptions(int index, void* udata)
 {
@@ -490,7 +643,7 @@ const char* s_getSramPathOptions(int index, void* udata)
   if (index < 0)
     return NULL;
 
-  return s_pathOptions[index].c_str();
+  return accessor.getPathOption(index);
 }
 
 const char* s_getStatePathOptions(int index, void* udata)
@@ -500,7 +653,13 @@ const char* s_getStatePathOptions(int index, void* udata)
   if (index < 0)
     return NULL;
 
-  return s_pathOptions[index].c_str();
+  return accessor.getPathOption(index);
+}
+
+const char* s_getSaveIntervalOptions(int index, void* udata)
+{
+  StatesPathAccessor accessor;
+  return accessor.getIntervalOption(index);
 }
 
 void States::showDialog()
@@ -517,26 +676,20 @@ void States::showDialog()
   Dialog db;
   db.init("Saving Settings");
 
-  if (s_pathOptions[0].empty())
-  {
-    for (unsigned i = 0; i < sizeof(s_pathOptions) / sizeof(s_pathOptions[0]); ++i)
-    {
-      std::string& option = s_pathOptions[i];
-      if (i & States::Path::State)
-        option = "States";
-      else
-        option = "Saves";
+  WORD y = 0;
 
-      if (i & States::Path::System)
-        option += "\\[System]";
-      if (i & States::Path::Core)
-        option += "\\[Core]";
-      if (i & States::Path::Game)
-        option += "\\[Game]";
+  int saveInterval = 0;
+  for (unsigned i = 0; i < sizeof(_saveIntervals) / sizeof(_saveIntervals[0]); ++i)
+  {
+    if (_saveIntervals[i] == _saveInterval)
+    {
+      saveInterval = i;
+      break;
     }
   }
-
-  WORD y = 0;
+  db.addLabel("SRAM Save Interval", 51001, 0, y, 60, 8);
+  db.addCombobox(51002, 65, y - 2, WIDTH - 65, 12, 80, s_getSaveIntervalOptions, NULL, &saveInterval);
+  y += LINE;
 
   int sramPath = 0;
   for (unsigned i = 0; i < sizeof(_sramPaths) / sizeof(_sramPaths[0]); ++i)
@@ -547,8 +700,8 @@ void States::showDialog()
       break;
     }
   }
-  db.addLabel("SRAM Path", 51001, 0, y, 50, 8);
-  db.addCombobox(51002, 55, y - 2, WIDTH - 55, 12, 140, s_getSramPathOptions, NULL, &sramPath);
+  db.addLabel("SRAM Path", 51003, 0, y, 60, 8);
+  db.addCombobox(51004, 65, y - 2, WIDTH - 65, 12, 140, s_getSramPathOptions, NULL, &sramPath);
   y += LINE;
 
   int statePath = 0;
@@ -560,8 +713,8 @@ void States::showDialog()
       break;
     }
   }
-  db.addLabel("Save State Path", 51003, 0, y, 50, 8);
-  db.addCombobox(51004, 55, y - 2, WIDTH - 55, 12, 140, s_getStatePathOptions, NULL, &statePath);
+  db.addLabel("Save State Path", 51005, 0, y, 60, 8);
+  db.addCombobox(51006, 65, y - 2, WIDTH - 65, 12, 140, s_getStatePathOptions, NULL, &statePath);
   y += LINE;
 
   db.addButton("OK", IDOK, WIDTH - 55 - 50, y, 50, 14, true);
@@ -569,6 +722,7 @@ void States::showDialog()
 
   if (db.show())
   {
+    _saveInterval = _saveIntervals[saveInterval];
     _sramPath = _sramPaths[sramPath];
     _statePath = _statePaths[statePath];
   }

--- a/src/States.h
+++ b/src/States.h
@@ -40,6 +40,10 @@ public:
   bool        loadState(const std::string& path);
   bool        loadState(unsigned ndx);
 
+  void        loadSRAM(libretro::Core* core);
+  void        saveSRAM(libretro::Core* core);
+  void        periodicSaveSRAM(libretro::Core* core);
+
   void        migrateFiles();
   bool        existsState(unsigned ndx);
 
@@ -62,15 +66,19 @@ protected:
 
   static const States::Path _sramPaths[];
   static const States::Path _statePaths[];
+  static const int _saveIntervals[];
 
   Logger* _logger;
   Config* _config;
   Video* _video;
 
   std::string _gameFileName;
-  int _system;
+  int _system = 0;
   std::string _coreName;
-  libretro::Core* _core;
+  libretro::Core* _core = NULL;
+  int _saveInterval = 0;
+  void* _lastSaveData = NULL;
+  time_t _lastSave = 0;
 
 private:
   std::string buildPath(Path path) const;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -593,6 +593,39 @@ std::string util::replaceFileName(const std::string& originalPath, const char* n
   return newPath;
 }
 
+std::string util::sanitizeFileName(const std::string& fileName)
+{
+  std::string sanitized = fileName;
+  for (int i = 0; i < sanitized.length(); ++i)
+  {
+    switch (sanitized[i])
+    {
+    case '<':
+    case '>':
+    case ':':
+    case '"':
+    case '/':
+    case '\\':
+    case '|':
+    case '?':
+    case '*':
+      sanitized[i] = '_';
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  if (!sanitized.empty() && (sanitized.back() == ' ' || sanitized.back() == '.'))
+  {
+    sanitized.pop_back();
+    sanitized.push_back('_');
+  }
+
+  return sanitized;
+}
+
 std::string util::directory(const std::string& path)
 {
   std::string newPath = path;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -23,6 +23,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include <sys/stat.h>
 #include <errno.h>
 #include <string.h>
+#include <share.h>
 
 #ifndef NO_MINIZ
 #include <miniz_zip.h>
@@ -105,7 +106,7 @@ FILE* util::openFile(Logger* logger, const std::string& path, const char* mode)
       /* fopen_s doesn't allow sharing files. if we're just reading, try again in sharing mode */
       if (mode[0] == 'r' && (!mode[1] || mode[1] == 'b'))
       {
-        file = _fsopen(path.c_str(), mode, _SH_DENYNO);
+        file = _fsopen(path.c_str(), mode, SH_DENYNO);
         err = (file) ? 0 : errno;
       }
     }
@@ -122,7 +123,7 @@ FILE* util::openFile(Logger* logger, const std::string& path, const char* mode)
       /* _wfopen_s doesn't allow sharing files. if we're just reading, try again in sharing mode */
       if (mode[0] == 'r' && (!mode[1] || mode[1] == 'b'))
       {
-        file = _wfsopen(unicodePath.c_str(), unicodeMode.c_str(), _SH_DENYNO);
+        file = _wfsopen(unicodePath.c_str(), unicodeMode.c_str(), SH_DENYNO);
         err = (file) ? 0 : errno;
       }
     }

--- a/src/Util.h
+++ b/src/Util.h
@@ -67,6 +67,7 @@ namespace util
   std::string fileNameWithExtension(const std::string& path);
   std::string extension(const std::string& path);
   std::string replaceFileName(const std::string& originalPath, const char* newFileName);
+  std::string sanitizeFileName(const std::string& fileName);
 
   std::string directory(const std::string& path);
 


### PR DESCRIPTION
closes #188 

![image](https://user-images.githubusercontent.com/32680403/85213228-b9710400-b318-11ea-8d49-b8474a83e65d.png)

The default value for this option is "None", as writing to disk has inherent overhead that could affect emulator performance. To minimize that impact, the SRAM is only written to disk if it has changed since the last interval. This requires keeping a second copy of the SRAM in memory for the comparison. A second copy is not kept if the interval is "None".

Additionally, the smallest interval is 10 seconds. It seems unlikely that the catastrophic error would occur immediately after using an internal save point, and if it did, it would likely be immediately, so any interval would be too long.