### PR TITLE
reload core when loading new game

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1503,13 +1503,10 @@ void Application::loadGame()
 
   if (!path.empty())
   {
-    /* disc-based system may append discs to the playlist, have to reload core to work around that */
-    if (_core.getNumDiscs() > 0)
-    {
-      std::string coreName = _coreName;
-      _fsm.unloadCore();
-      _fsm.loadCore(coreName);
-    }
+    /* some cores need to be reset to flush any previous state information */
+    /* this also ensures the disc menu is reset if the core built it dynamically */
+    /* ASSERT: loadCore will unload the current core, even if it's the same core */
+    _fsm.loadCore(_coreName);
 
     _fsm.loadGame(path);
   }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1506,7 +1506,8 @@ void Application::loadGame()
     /* some cores need to be reset to flush any previous state information */
     /* this also ensures the disc menu is reset if the core built it dynamically */
     /* ASSERT: loadCore will unload the current core, even if it's the same core */
-    _fsm.loadCore(_coreName);
+    if (_core.gameLoaded())
+      _fsm.loadCore(_coreName);
 
     _fsm.loadGame(path);
   }

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -61,6 +61,7 @@ namespace libretro
     inline bool                    getSupportsNoGame()      const { return _supportsNoGame; }
     inline bool                    getSupportAchievements() const { return _supportAchievements; }
     inline void                    unloadGame()                   { _core.unloadGame(); }
+    inline bool                    gameLoaded()             const { return _gameLoaded; }
 
     inline unsigned                getNumDiscs()            const { return (_diskControlInterface != NULL) ? _diskControlInterface->get_num_images() : 0; }
     inline unsigned                getCurrentDiscIndex()    const { return (_diskControlInterface != NULL) ? _diskControlInterface->get_image_index() : 0; }


### PR DESCRIPTION
Fixes an issue where some state can leak from a previously loaded game into the newly loaded game.

We already do this when opening items from the recent menu and for disc-based games. This just extends the behavior for all games opened from the "Load Game..." menu item.

Tested by loading an MSX game, then loading a different MSX game. Without the change, the second game would crash the emulator, fail to load, or corrupt the image.