### PR TITLE
fix missing video when running on OpenGL 2.0

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -165,11 +165,6 @@ bool Application::init(const char* title, int width, int height)
     }
   }
 
-  int major, minor;
-  SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &major);
-  SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minor);
-  _logger.info(TAG "Got OpenGL %d.%d", major, minor);
-
   inited = kWindowInited;
 
   Gl::init(&_logger);

--- a/src/Gl.h
+++ b/src/Gl.h
@@ -74,5 +74,7 @@ namespace Gl
   void blendEquation(GLenum mode);
   void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
   void drawArrays(GLenum mode, GLint first, GLsizei count);
+
+  int getVersion();
 }
 

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -159,6 +159,15 @@ bool Video::setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsi
   if (!hardwareRender && _hw.enabled)
     postHwRenderReset();
 
+  if (hardwareRender)
+  {
+    if (Gl::getVersion() < 300)
+    {
+      MessageBox(NULL, "OpenGL 3.0 required for hardware rendering", "Initialization failed", MB_OK | MB_ICONERROR);
+      return false;
+    }
+  }
+
   _hw.enabled = hardwareRender;
   _hw.callback = hwRenderCallback;
 
@@ -586,15 +595,19 @@ bool Video::ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float
     { winScaleX,  winScaleY,      0.0f,      0.0f}
   };
 
-  if (_vertexArray != 0)
-    Gl::deleteVertexArrays(1, &_vertexArray);
+  if (_hw.enabled)
+  {
+    if (_vertexArray != 0)
+      Gl::deleteVertexArrays(1, &_vertexArray);
+
+    Gl::genVertexArray(1, &_vertexArray);
+    if (_vertexArray == 0)
+      return false;
+    Gl::bindVertexArray(_vertexArray);
+  }
+
   if (_vertexBuffer != 0)
     Gl::deleteBuffers(1, &_vertexBuffer);
-
-  Gl::genVertexArray(1, &_vertexArray);
-  if (_vertexArray == 0)
-    return false;
-  Gl::bindVertexArray(_vertexArray);
 
   Gl::genBuffers(1, &_vertexBuffer);
   if (_vertexBuffer == 0)

--- a/src/libretro/BareCore.cpp
+++ b/src/libretro/BareCore.cpp
@@ -300,9 +300,12 @@ bool libretro::BareCore::loadGameSpecial(unsigned game_type, const struct retro_
 
 void libretro::BareCore::unloadGame() const
 {
-  _logger->debug(TAG "Calling %s", __FUNCTION__);
-  _unloadGame();
-  _logger->debug(TAG "Called  %s", __FUNCTION__);
+  if (_unloadGame)
+  {
+    _logger->debug(TAG "Calling %s", __FUNCTION__);
+    _unloadGame();
+    _logger->debug(TAG "Called  %s", __FUNCTION__);
+  }
 }
 
 unsigned libretro::BareCore::getRegion() const


### PR DESCRIPTION
Some of the changes to support hardware rendering require OpenGL 3.0, but not all of our userbase is running OpenGL 3.0. This isolates the 3.0 features to hardware rendering mode, allowing those users access to the same set of functionality previously available to them. They will receive an error trying to activate hardware rendering mode.

Also fixed the log message that reports the current OpenGL version to actually report the current version instead of the version we asked SDL to get (which was the default - 2.1).