### PR TITLE
ensure sram subfolders exist before trying to write file

### DIFF
--- a/src/States.cpp
+++ b/src/States.cpp
@@ -339,14 +339,20 @@ void States::loadSRAM(libretro::Core* core)
   _lastSave = time(NULL);
 }
 
+void States::saveSRAM(void* sramData, size_t sramSize)
+{
+  std::string sramPath = getSRamPath();
+  util::ensureDirectoryExists(util::directory(sramPath));
+  util::saveFile(_logger, sramPath, sramData, sramSize);
+}
+
 void States::saveSRAM(libretro::Core* core)
 {
   size_t sramSize = core->getMemorySize(RETRO_MEMORY_SAVE_RAM);
   if (sramSize != 0)
   {
-    void* data = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
-    std::string sramPath = getSRamPath();
-    util::saveFile(_logger, sramPath, data, sramSize);
+    void* sramData = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
+    saveSRAM(sramData, sramSize);
   }
 }
 
@@ -370,8 +376,7 @@ void States::periodicSaveSRAM(libretro::Core* core)
         memcpy(_lastSaveData, data, sramSize);
 
         // TODO: offload this to a background thread?
-        std::string sramPath = getSRamPath();
-        util::saveFile(_logger, sramPath, _lastSaveData, sramSize);
+        saveSRAM(_lastSaveData, sramSize);
       }
     }
 

--- a/src/States.h
+++ b/src/States.h
@@ -87,4 +87,6 @@ private:
 
   std::string getSRamPath(Path path) const;
   std::string getStatePath(unsigned ndx, Path path) const;
+
+  void saveSRAM(void* sramData, size_t sramSize);
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -304,7 +304,10 @@ bool util::saveFile(Logger* logger, const std::string& path, const void* data, s
 {
   FILE* file = util::openFile(logger, path, "wb");
   if (file == NULL)
+  {
+    logger->error(TAG "Error creating file \"%s\": %s", path.c_str(), strerror(errno));
     return false;
+  }
 
   if (fwrite(data, 1, size, file) != size)
   {

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -24,6 +24,8 @@ SOFTWARE.
 
 #include "Core.h"
 
+#include "Util.h"
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -63,7 +65,7 @@ namespace
   };
 
   // Dummy components
-  class Logger: public libretro::LoggerComponent
+  class DummyLogger: public libretro::LoggerComponent
   {
   public:
     virtual void vprintf(enum retro_log_level level, const char* fmt, va_list args) override
@@ -74,7 +76,7 @@ namespace
     }
   };
 
-  class Config: public libretro::ConfigComponent
+  class DummyConfig: public libretro::ConfigComponent
   {
   public:
     virtual const char* getCoreAssetsDirectory() override
@@ -121,7 +123,7 @@ namespace
     }
   };
 
-  class VideoContext : public libretro::VideoContextComponent
+  class DummyVideoContext : public libretro::VideoContextComponent
   {
   public:
     virtual void swapBuffers() override
@@ -129,7 +131,7 @@ namespace
     }
   };
 
-  class Video: public libretro::VideoComponent
+  class DummyVideo: public libretro::VideoComponent
   {
   public:
     virtual void setEnabled(bool enabled) override
@@ -190,7 +192,7 @@ namespace
     }
   };
 
-  class Audio: public libretro::AudioComponent
+  class DummyAudio: public libretro::AudioComponent
   {
   public:
     virtual bool setRate(double rate) override
@@ -206,7 +208,7 @@ namespace
     }
   };
 
-  class Input: public libretro::InputComponent
+  class DummyInput: public libretro::InputComponent
   {
   public:
     virtual void setInputDescriptors(const struct retro_input_descriptor* descs, unsigned count) override
@@ -252,7 +254,7 @@ namespace
     }
   };
 
-  class Allocator: public libretro::AllocatorComponent
+  class DummyAllocator: public libretro::AllocatorComponent
   {
   public:
     virtual void reset() override {}
@@ -267,13 +269,13 @@ namespace
 }
 
 // Instances of the dummy components to use in CoreWrap instances by default
-static Logger       s_logger;
-static Config       s_config;
-static VideoContext s_videoContext;
-static Video        s_video;
-static Audio        s_audio;
-static Input        s_input;
-static Allocator    s_allocator;
+static DummyLogger       s_logger;
+static DummyConfig       s_config;
+static DummyVideoContext s_videoContext;
+static DummyVideo        s_video;
+static DummyAudio        s_audio;
+static DummyInput        s_input;
+static DummyAllocator    s_allocator;
 
 // Helper function for the memory map interface
 static bool preprocessMemoryDescriptors(struct retro_memory_descriptor* descriptors, unsigned num_descriptors);
@@ -602,7 +604,7 @@ char* libretro::Core::strdup(const char* str)
 
 bool libretro::Core::setRotation(unsigned data)
 {
-  _video->setRotation((Video::Rotation)data);
+  _video->setRotation((VideoComponent::Rotation)data);
   return true;
 }
 
@@ -841,6 +843,7 @@ bool libretro::Core::getCoreAssetsDirectory(const char** data) const
 bool libretro::Core::getSaveDirectory(const char** data) const
 {
   *data = _config->getSaveDirectory();
+  util::ensureDirectoryExists(*data);
   return true;
 }
 


### PR DESCRIPTION
Fixes an error where SRAM would silently not be written when using an SRAM path other than `Saves` and not migrating data. Migrated data would correctly create the subfolder, but if no data was migrated, the folder would not exist and the save would fail.