### PR TITLE
reset vertex array when switching from hardware to non-hardware mode

### DIFF
--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -595,7 +595,7 @@ bool Video::ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float
     { winScaleX,  winScaleY,      0.0f,      0.0f}
   };
 
-  if (_vertexArray)
+  if (_vertexArray != 0)
   {
     Gl::deleteVertexArrays(1, &_vertexArray);
     _vertexArray = 0;

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -676,8 +676,9 @@ GLuint Video::createTexture(unsigned width, unsigned height, retro_pixel_format 
 
 bool Video::ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter)
 {
+  const bool hwEnabled = (_hw.frameBuffer != 0);
   if (_texture == 0
-    || (_hw.enabled && _hw.frameBuffer == 0)
+    || (_hw.enabled != hwEnabled)
     || width > _textureWidth || height > _textureHeight
     || pixelFormat != _pixelFormat
     || linearFilter != _linearFilter)

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -167,6 +167,12 @@ bool Video::setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsi
       return false;
     }
   }
+  else if (_vertexArray)
+  {
+    Gl::disableVertexAttribArray(_vertexArray);
+    Gl::deleteVertexArrays(1, &_vertexArray);
+    _vertexArray = 0;
+  }
 
   _hw.enabled = hardwareRender;
   _hw.callback = hwRenderCallback;

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -167,12 +167,6 @@ bool Video::setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsi
       return false;
     }
   }
-  else if (_vertexArray)
-  {
-    Gl::disableVertexAttribArray(_vertexArray);
-    Gl::deleteVertexArrays(1, &_vertexArray);
-    _vertexArray = 0;
-  }
 
   _hw.enabled = hardwareRender;
   _hw.callback = hwRenderCallback;
@@ -601,11 +595,14 @@ bool Video::ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float
     { winScaleX,  winScaleY,      0.0f,      0.0f}
   };
 
+  if (_vertexArray)
+  {
+    Gl::deleteVertexArrays(1, &_vertexArray);
+    _vertexArray = 0;
+  }
+
   if (_hw.enabled)
   {
-    if (_vertexArray != 0)
-      Gl::deleteVertexArrays(1, &_vertexArray);
-
     Gl::genVertexArray(1, &_vertexArray);
     if (_vertexArray == 0)
       return false;


### PR DESCRIPTION
fixes issue where switching from a hardware rendered core to a non-hardware rendered core causes the image to be inverted and zoomed in.

caused by #211 - the vertex buffer was not being destroyed when switching to a non-hardware rendered core.