### PR TITLE
Add Mesen and Mesen-S to supported cores

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -123,6 +123,15 @@
     "name": "Beetle WonderSwan",
     "systems": [53]
   },
+  "mesen_libretro":{
+    "name": "Mesen",
+    "systems": [7]
+  },
+  "mesen-s_libretro":{
+    "name": "Mesen-S",
+    "extensions": "sfc|smc|swc|fig|bs",
+    "systems": [3]
+  },
   "mgba_libretro":{
     "name": "mGBA",
     "extensions": "gba",


### PR DESCRIPTION
I've tested both cores with all applicable systems and can't see any issues.