### PR TITLE
also copy mingw dlls for core dependencies

### DIFF
--- a/etc/CopyDLLs.bat
+++ b/etc/CopyDLLs.bat
@@ -1,0 +1,47 @@
+@echo off
+@setlocal
+
+set W64=0
+if "%1"=="x64" set W64=1
+
+set PROJECTDIR=%2
+set BINDIR=%3
+
+rem === SDL2 is required by RALibretro, libstdc++-6 and libwinpthread-1 are required by cores ===
+set LIBSTDCPP=libstdc++-6.dll
+set LIBPTHREAD=libwinpthread-1.dll
+set SDL=SDL2.dll
+
+set SDLSRC=SDL2\lib\x86
+if %W64% equ 1 set SDLSRC=SDL2\lib\x64
+if not exist "%BINDIR%\%SDL%" (
+    echo Copying SDL2.dll from %SDLSRC%
+    copy /y "%PROJECTDIR%\%SDLSRC%\%SDL%" "%BINDIR%"
+)
+
+if exist "%BINDIR%\%LIBSTDC%" (
+    if exist "%BINDIR%\%LIBPTHREAD%" (
+        exit /B 0
+    )
+)
+
+if %W64% equ 1 if exist C:\msys64\mingw64 set SRCDIR=C:\msys64\mingw64
+if %W64% neq 1 if exist C:\msys64\mingw32 set SRCDIR=C:\msys64\mingw32
+if "%SRCDIR%"=="" set SRCDIR="%MINGW%"
+if not exist "%SRCDIR%" set SRCDIR=C:\mingw
+)
+
+if not exist "%SRCDIR%" (
+    echo Could not locate MINGW
+    exit /B 1
+)
+
+if not exist "%BINDIR%\%LIBSTDCPP%" (
+    echo Copying %LIBSTDCPP% from %SRCDIR%
+    copy /y "%SRCDIR%\bin\%LIBSTDCPP%" "%BINDIR%"
+)
+
+if not exist "%BINDIR%\%LIBPTHREAD%" (
+    echo Copying %LIBPTHREAD% from %SRCDIR%
+    copy /y "%SRCDIR%\bin\%LIBPTHREAD%" "%BINDIR%"
+)

--- a/etc/CopyDLLs.bat
+++ b/etc/CopyDLLs.bat
@@ -33,7 +33,7 @@ if not exist "%SRCDIR%" set SRCDIR=C:\mingw
 
 if not exist "%SRCDIR%" (
     echo Could not locate MINGW
-    exit /B 1
+    exit /B 0
 )
 
 if not exist "%BINDIR%\%LIBSTDCPP%" (

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -118,7 +118,7 @@
       <Message>Copying $(TargetFileName) to bin directory</Message>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>xcopy /D /Q /Y $(ProjectDir)SDL2\lib\x86\SDL2.dll $(SolutionDir)bin\
+      <Command>$(SolutionDir)etc\CopyDLLs.bat x86 $(ProjectDir) $(SolutionDir)bin
 $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -149,7 +149,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
       <Command>$(ProjectDir)..\etc\MakeGitCpp.bat</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /D /Q /Y $(ProjectDir)SDL2\lib\x86\SDL2.dll $(SolutionDir)bin\
+      <Command>$(SolutionDir)etc\CopyDLLs.bat x86 $(ProjectDir) $(SolutionDir)bin
 $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -179,7 +179,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>xcopy /D /Q /Y $(SolutionDir)bin\Cores\cores.json $(SolutionDir)bin64\Cores\
-xcopy /D /Q /Y $(ProjectDir)SDL2\lib\x64\SDL2.dll $(SolutionDir)bin64\
+$(SolutionDir)etc\CopyDLLs.bat x64 $(ProjectDir) $(SolutionDir)\bin64
 $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -211,7 +211,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>xcopy /D /Q /Y $(SolutionDir)bin\Cores\cores.json $(SolutionDir)bin64\Cores\
-xcopy /D /Q /Y $(ProjectDir)SDL2\lib\x64\SDL2.dll $(SolutionDir)bin64\
+$(SolutionDir)etc\CopyDLLs.bat x64 $(ProjectDir) $(SolutionDir)\bin64
 $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
fixes "unable to load core" error when running from build directory on clean checkout.

#210 removed several DLLs from the repository, but at least a couple of them are required by the cores. Attempting to load a core without them present generates an "unable to load core" error. Rather than add them back into the repository, this attempts to copy them from the source (mingw installation).

For users who don't have mingw installed, the releases can be downloaded from the website and the DLLs copied from there.