### PR TITLE
resample each audio channel separately

### DIFF
--- a/src/components/Audio.cpp
+++ b/src/components/Audio.cpp
@@ -21,6 +21,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <SDL_timer.h>
 #include <string.h>
+#include <math.h>
 
 #define TAG "[AUD] "
 

--- a/src/components/Audio.cpp
+++ b/src/components/Audio.cpp
@@ -129,7 +129,8 @@ size_t Fifo::free()
 bool Audio::init(libretro::LoggerComponent* logger, double sample_rate, int channels, Fifo* fifo)
 {
   _coreRate = 0;
-  _resampler = NULL;
+  _resamplerLeft = NULL;
+  _resamplerRight = NULL;
 
   _logger = logger;
   _sampleRate = sample_rate;
@@ -144,33 +145,55 @@ bool Audio::init(libretro::LoggerComponent* logger, double sample_rate, int chan
 
 void Audio::destroy()
 {
-  if (_resampler != NULL)
+  if (_resamplerLeft != NULL)
   {
-    speex_resampler_destroy(_resampler);
+    speex_resampler_destroy(_resamplerLeft);
+    _resamplerLeft = NULL;
+  }
+
+  if (_resamplerRight != NULL)
+  {
+    speex_resampler_destroy(_resamplerRight);
+    _resamplerRight = NULL;
   }
 }
 
 bool Audio::setRate(double rate)
 {
-  if (_resampler != NULL)
-  {
-    speex_resampler_destroy(_resampler);
-  }
+  destroy();
 
   _coreRate = rate;
   _currentRatio = _originalRatio = _sampleRate / _coreRate;
 
-  int error;
-  _resampler = speex_resampler_init(2, _coreRate, _sampleRate, SPEEX_RESAMPLER_QUALITY_DEFAULT, &error);
-
-  if (_resampler == NULL)
+  if (_sampleRate == _coreRate)
   {
-    _logger->error(TAG "speex_resampler_init: %s", speex_resampler_strerror(error));
-    return false;
+    _logger->info(TAG "Resampler not needed to convert from %f to %f", _coreRate, _sampleRate);
   }
   else
   {
+    int error;
+    _resamplerLeft = speex_resampler_init(1, _coreRate, _sampleRate, SPEEX_RESAMPLER_QUALITY_DEFAULT, &error);
+
+    if (_resamplerLeft == NULL)
+    {
+      _logger->error(TAG "speex_resampler_init: %s", speex_resampler_strerror(error));
+      return false;
+    }
+
+    _resamplerRight = speex_resampler_init(1, _coreRate, _sampleRate, SPEEX_RESAMPLER_QUALITY_DEFAULT, &error);
+    if (_resamplerRight == NULL)
+    {
+      _logger->error(TAG "speex_resampler_init: %s", speex_resampler_strerror(error));
+      return false;
+    }
+
     _logger->info(TAG "Resampler initialized to convert from %f to %f", _coreRate, _sampleRate);
+
+    /* mimic interleaved support */
+    speex_resampler_set_input_stride(_resamplerLeft, 2);
+    speex_resampler_set_input_stride(_resamplerRight, 2);
+    speex_resampler_set_output_stride(_resamplerLeft, 2);
+    speex_resampler_set_output_stride(_resamplerRight, 2);
   }
 
   return true;
@@ -190,24 +213,25 @@ void Audio::mix(const int16_t* samples, size_t frames)
     /* no resampling needed */
     output = (int16_t*)samples;
     out_len = frames * 2;
-    output_size = frames * 2 * sizeof(int16_t);
   }
   else
   {
-    // /* adjust the audio input rate. */
-    //const int    half_size = (int)_fifo->size() / 2;
-    //const int    delta_mid = (int)avail - half_size;
-    //const double direction = (double)delta_mid / (double)half_size;
-    //const double rateControlDelta = 0.005;
-    //const double adjust = 1.0 + rateControlDelta * direction;
+#if 0 /* adjusting the sample rate between resampling calls can cause clicking if sufficient data is still in the buffer from the previous resample */
+    /* adjust the audio input rate. */
+    const int    half_size = (int)_fifo->size() / 2;
+    const int    delta_mid = (int)avail - half_size;
+    const double direction = (double)delta_mid / (double)half_size;
+    const double rateControlDelta = 0.005;
+    const double adjust = 1.0 + rateControlDelta * direction;
 
-    //_currentRatio = _originalRatio * adjust;
+    _currentRatio = _originalRatio * adjust;
 
-    //if (_currentRatio != _originalRatio)
-    //  _logger->debug(TAG "Original ratio %f adjusted by %f to %f", _originalRatio, adjust, _currentRatio);
+    if (_currentRatio != _originalRatio)
+      _logger->debug(TAG "Original ratio %f adjusted by %f to %f", _originalRatio, adjust, _currentRatio);
+#endif
 
     /* allocate output buffer */
-    out_len = (spx_uint32_t)(frames * 2 * _currentRatio);
+    out_len = (spx_uint32_t)ceil(frames * 2 * _currentRatio);
     out_len += (out_len & 1);  /* don't send incomplete frames */
 
     output_size = out_len * sizeof(int16_t);
@@ -224,18 +248,36 @@ void Audio::mix(const int16_t* samples, size_t frames)
     spx_uint32_t out_frames = out_len / 2;
     _logger->debug(TAG "Resampling %u samples to %u", in_frames * 2, out_frames * 2);
 
-    speex_resampler_reset_mem(_resampler);
-    const int error = speex_resampler_process_interleaved_int(_resampler, samples, &in_frames, output, &out_frames);
-
-    if (error != RESAMPLER_ERR_SUCCESS)
     {
-      memset(output, 0, output_size);
-      _logger->error(TAG "speex_resampler_process_interleaved_int: %s", speex_resampler_strerror(error));
+      /* speex seems to have issues upsampling SNES (32KHz) properly without introducing static.
+       * This seems to be caused by whatever state is maintained between resampling calls. The
+       * interleaved resampler only remembers state for the last channel - using one resampler
+       * and calling speex_resampler_process_interleaved_int was creating static in the left
+       * channel. To address that, we use two resamplers (one for each channel) and let each keep
+       * their own state.
+       */
+      int error = speex_resampler_process_int(_resamplerLeft, 0, samples, &in_frames, output, &out_frames);
+      if (error == RESAMPLER_ERR_SUCCESS)
+      {
+        error = speex_resampler_process_int(_resamplerRight, 0, samples + 1, &in_frames, output + 1, &out_frames);
+        if (error == RESAMPLER_ERR_SUCCESS)
+        {
+          /* update with the actual number of frames created */
+          out_len = out_frames * 2;
+        }
+      }
+
+      if (error != RESAMPLER_ERR_SUCCESS)
+      {
+        memset(output, 0, output_size);
+        _logger->error(TAG "speex_resampler_process_interleaved_int: %s", speex_resampler_strerror(error));
+      }
     }
   }
 
   /* flush to FIFO queue */
-  const size_t needed = (output_size / 2) * _channels;
+  output_size = out_len * sizeof(int16_t);
+  const size_t needed = out_len * _channels;
   if (avail < needed)
   {
     _logger->debug(TAG "Waiting for FIFO (need %zu bytes but only %zu available), sleeping", needed, avail);

--- a/src/components/Audio.cpp
+++ b/src/components/Audio.cpp
@@ -220,14 +220,17 @@ void Audio::mix(const int16_t* samples, size_t frames)
     }
 
     /* do the resampling */
-    spx_uint32_t in_len = frames * 2; /* input is 2-channel */
-    _logger->debug(TAG "Resampling %u samples to %u", in_len, out_len);
-    int error = speex_resampler_process_int(_resampler, 0, samples, &in_len, output, &out_len);
+    spx_uint32_t in_frames = frames;
+    spx_uint32_t out_frames = out_len / 2;
+    _logger->debug(TAG "Resampling %u samples to %u", in_frames * 2, out_frames * 2);
+
+    speex_resampler_reset_mem(_resampler);
+    const int error = speex_resampler_process_interleaved_int(_resampler, samples, &in_frames, output, &out_frames);
 
     if (error != RESAMPLER_ERR_SUCCESS)
     {
       memset(output, 0, output_size);
-      _logger->error(TAG "speex_resampler_process_int: %s", speex_resampler_strerror(error));
+      _logger->error(TAG "speex_resampler_process_interleaved_int: %s", speex_resampler_strerror(error));
     }
   }
 

--- a/src/components/Audio.h
+++ b/src/components/Audio.h
@@ -67,7 +67,8 @@ protected:
 
   double _currentRatio;
   double _originalRatio;
-  SpeexResamplerState* _resampler;
+  SpeexResamplerState* _resamplerLeft;
+  SpeexResamplerState* _resamplerRight;
 
   Fifo* _fifo;
 };

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -1490,11 +1490,18 @@ void libretro::Core::videoRefreshCallback(const void* data, unsigned width, unsi
 
 size_t libretro::Core::audioSampleBatchCallback(const int16_t* data, size_t frames)
 {
+#if 0
+  /* retroarch resamples every packet as it comes in. to minimize the overhead of resampling,
+   * we buffer up an entire frame's worth of audio and resample it in a single pass.
+   */
+  _audio->mix(data, frames);
+#else
   if (_samplesCount < SAMPLE_COUNT - frames * 2 + 1)
   {
     memcpy(_samples + _samplesCount, data, frames * 2 * sizeof(int16_t));
     _samplesCount += frames * 2;
   }
+#endif
 
   return frames;
 }

--- a/src/speex/version.txt
+++ b/src/speex/version.txt
@@ -1,0 +1,11 @@
+SpeexDSP 1.2rc3
+https://www.speex.org/downloads/
+
+Speex website indicates it has been superceded by Opus, but Opus documentation specifically 
+states it does not have a resampler, and points back at Speex:
+
+https://gitlab.xiph.org/xiph/opusfile/-/blob/master/include/opusfile.h#L59-62
+
+    (the <tt>libopusfile</tt> API does not currently provide a resampler, but
+    <a href="https://www.speex.org/docs/manual/speex-manual/node7.html#SECTION00760000000000000000">the
+    Speex resampler</a> is a good choice if you need one)


### PR DESCRIPTION
This fixes low-level background static and occasional clicking in the Snes9x core.

The first issue is that we were using a single-channel resampler to resample both channels, so the interleaved data was becoming slightly entangled. I tried using the `speex_resampler_process_interleaved_int` function, and that eliminated the background static, but the occasional clicking persisted. 

Apparently, speex's resampler can only carryover state from one call to the next for a single channel (whichever channel was the last processed). To address that, I ended up creating two resamplers - one for each channel, and with some additional setup, I'm able to still process the interleaved data without having to deconstruct and reconstruct it.

Also added some logic to prevent an infinite loop if the FIFO gets full.
