### PR TITLE
implement RETRO_ENVIRONMENT_GET_FASTFORWARDING

### DIFF
--- a/src/Fsm.cpp
+++ b/src/Fsm.cpp
@@ -11,7 +11,6 @@ const char* Fsm::stateName(State state) const {
     case State::GamePaused: return "GamePaused";
     case State::GamePausedNoOvl: return "GamePausedNoOvl";
     case State::GameRunning: return "GameRunning";
-    case State::GameTurbo: return "GameTurbo";
     case State::Quit: return "Quit";
     case State::Start: return "Start";
     default: break;
@@ -190,42 +189,6 @@ bool Fsm::loadCore(const_string core) {
     }
     break;
 
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-
-        return false;
-      }
-
-      bool __ok = unloadGame() &&
-                  unloadCore() &&
-                  loadCore(core);
-
-      if (__ok) {
-        after(__state);
-        after();
-
-      }
-      else {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-      }
-
-      return __ok;
-    }
-    break;
-
     case State::Start: {
       if (!before()) {
 #ifdef DEBUG_FSM
@@ -244,9 +207,13 @@ bool Fsm::loadCore(const_string core) {
       }
 
 
+
       if (!ctx.loadCore(core)) {
+
         return false;
+
       }
+
     
       __state = State::CoreLoaded;
       after(__state);
@@ -405,77 +372,6 @@ bool Fsm::loadGame(const_string path) {
     }
     break;
 
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      bool __ok = unloadGame() &&
-                  loadGame(path);
-
-      if (__ok) {
-        after(__state);
-        after();
-
-      }
-      else {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-      }
-
-      return __ok;
-    }
-    break;
-
-    default: break;
-  }
-
-  return false;
-}
-
-bool Fsm::normal() {
-  switch (__state) {
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      __state = State::GameRunning;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-      return true;
-    }
-    break;
-
     default: break;
   }
 
@@ -500,35 +396,7 @@ bool Fsm::pauseGame() {
 
         return false;
       }
- 
-      __state = State::GamePaused;
-      after(__state);
-      after();
 
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
-#endif
-
-        return false;
-      }
-   
       __state = State::GamePaused;
       after(__state);
       after();
@@ -566,42 +434,13 @@ bool Fsm::pauseGameNoOvl() {
       }
 
 
-      if (ctx.hardcore()) {
-        return false;
-      }
-    
-      __state = State::GamePausedNoOvl;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GamePausedNoOvl));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePausedNoOvl));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePausedNoOvl));
-#endif
-
-        return false;
-      }
-
 
       if (ctx.hardcore()) {
+
         return false;
+
       }
+
     
       __state = State::GamePausedNoOvl;
       after(__state);
@@ -728,41 +567,6 @@ bool Fsm::quit() {
     break;
 
     case State::GameRunning: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::Quit));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::Quit));
-#endif
-
-        return false;
-      }
-
-      bool __ok = unloadGame() &&
-                  quit();
-
-      if (__ok) {
-        after(__state);
-        after();
-
-      }
-      else {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::Quit));
-#endif
-      }
-
-      return __ok;
-    }
-    break;
-
-    case State::GameTurbo: {
       if (!before()) {
 #ifdef DEBUG_FSM
         ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::Quit));
@@ -934,41 +738,6 @@ bool Fsm::resetGame() {
     }
     break;
 
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-
-        return false;
-      }
-
-      bool __ok = normal() &&
-                  resetGame();
-
-      if (__ok) {
-        after(__state);
-        after();
-
-      }
-      else {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
-#endif
-      }
-
-      return __ok;
-    }
-    break;
-
     default: break;
   }
 
@@ -1021,7 +790,7 @@ bool Fsm::resumeGame() {
 
         return false;
       }
-    
+
       __state = State::GameRunning;
       after(__state);
       after();
@@ -1086,8 +855,12 @@ bool Fsm::step() {
         return false;
       }
 
+
+
       if (ctx.hardcore()) {
-          return false;
+
+        return false;
+
       }
 
       __state = State::FrameStep;
@@ -1118,8 +891,12 @@ bool Fsm::step() {
         return false;
       }
 
+
+
       if (ctx.hardcore()) {
-          return false;
+
+        return false;
+
       }
 
       __state = State::FrameStep;
@@ -1151,9 +928,13 @@ bool Fsm::step() {
       }
 
 
+
       if (ctx.hardcore()) {
+
         return false;
+
       }
+
     
       __state = State::FrameStep;
       after(__state);
@@ -1161,130 +942,6 @@ bool Fsm::step() {
 
 #ifdef DEBUG_FSM
       ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::FrameStep));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::FrameStep));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::FrameStep));
-#endif
-
-        return false;
-      }
-
-      if (ctx.hardcore()) {
-          return false;
-      }
-
-      __state = State::FrameStep;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::FrameStep));
-#endif
-      return true;
-    }
-    break;
-
-    default: break;
-  }
-
-  return false;
-}
-
-bool Fsm::turbo() {
-  switch (__state) {
-    case State::GamePaused: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-
-      __state = State::GameTurbo;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GamePausedNoOvl: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-   
-      __state = State::GameTurbo;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GameRunning: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
-#endif
-
-        return false;
-      }
-    
-      __state = State::GameTurbo;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameTurbo));
 #endif
       return true;
     }
@@ -1421,42 +1078,13 @@ bool Fsm::unloadGame() {
       }
 
 
-      if (!ctx.unloadGame()) {
-        return false;
-      }
-    
-      __state = State::CoreLoaded;
-      after(__state);
-      after();
-
-#ifdef DEBUG_FSM
-      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-      return true;
-    }
-    break;
-
-    case State::GameTurbo: {
-      if (!before()) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-
-        return false;
-      }
-
-      if (!before(__state)) {
-#ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::CoreLoaded));
-#endif
-
-        return false;
-      }
-
 
       if (!ctx.unloadGame()) {
+
         return false;
+
       }
+
     
       __state = State::CoreLoaded;
       after(__state);
@@ -1474,5 +1102,4 @@ bool Fsm::unloadGame() {
 
   return false;
 }
-
 

--- a/src/Fsm.fsm
+++ b/src/Fsm.fsm
@@ -113,8 +113,6 @@ fsm Fsm {
       }
     }
     
-    turbo() => GameTurbo;
-
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
         forbid;
@@ -138,8 +136,6 @@ fsm Fsm {
         forbid;
       }
     }
-
-    turbo() => GameTurbo;
 
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
@@ -165,8 +161,6 @@ fsm Fsm {
       }
     }
 
-    turbo() => GameTurbo;
-
     unloadGame() => CoreLoaded {
       if (!ctx.unloadGame()) {
         forbid;
@@ -182,38 +176,6 @@ fsm Fsm {
 
   FrameStep {
     resumeGame() => GamePaused;
-  }
-
-  GameTurbo {
-    normal() => GameRunning;
-
-    resetGame() => normal() => resetGame();
-
-    unloadGame() => CoreLoaded {
-      if (!ctx.unloadGame()) {
-        forbid;
-      }
-    }
-
-    step() => FrameStep {
-      if (ctx.hardcore()) {
-        forbid;
-      }
-    }
-
-    pauseGame() => GamePaused;
-
-    pauseGameNoOvl() => GamePausedNoOvl {
-      if (ctx.hardcore()) {
-        forbid;
-      }
-    }
-
-    loadCore(const_string core) => unloadGame() => unloadCore() => loadCore(core);
-
-    loadGame(const_string path) => unloadGame() => loadGame(path);
-
-    quit() => unloadGame() => quit();
   }
 }
 

--- a/src/Fsm.h
+++ b/src/Fsm.h
@@ -18,7 +18,6 @@ public:
     GamePaused,
     GamePausedNoOvl,
     GameRunning,
-    GameTurbo,
     Quit,
     Start,
   };
@@ -33,14 +32,12 @@ public:
 
   bool loadCore(const_string core);
   bool loadGame(const_string path);
-  bool normal();
   bool pauseGame();
   bool pauseGameNoOvl();
   bool quit();
   bool resetGame();
   bool resumeGame();
   bool step();
-  bool turbo();
   bool unloadCore();
   bool unloadGame();
 
@@ -53,4 +50,3 @@ protected:
   Application& ctx;
   State __state;
 };
-

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -45,6 +45,9 @@ public:
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
+  virtual bool getFastForwarding() override { return _fastForwarding; }
+  virtual void setFastForwarding(bool value) override { _fastForwarding = value; }
+
   void setSaveDirectory(const std::string& path) { _saveFolder = path; }
 
   const char* getRootFolder()
@@ -92,6 +95,7 @@ protected:
   std::unordered_map<std::string, std::string> _selections;
 
   bool _updated;
+  bool _fastForwarding;
 
   std::string _key;
 };

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -117,6 +117,9 @@ namespace libretro
     virtual void setVariableDisplay(const struct retro_core_option_display* display) = 0;
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;
+
+    virtual bool getFastForwarding() = 0;
+    virtual void setFastForwarding(bool value) = 0;
   };
 
   /**

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -121,6 +121,16 @@ namespace
       (void)variable;
       return NULL;
     }
+
+    virtual bool getFastForwarding() override
+    {
+      return false;
+    }
+
+    virtual void setFastForwarding(bool value) override
+    {
+      (void)value;
+    }
   };
 
   class DummyVideoContext : public libretro::VideoContextComponent
@@ -568,6 +578,7 @@ void libretro::Core::reset()
   _pixelFormat = RETRO_PIXEL_FORMAT_UNKNOWN;
   _supportsNoGame = false;
   _supportAchievements = false;
+  _fastForwarding = false;
   _inputDescriptorsCount = 0;
   _inputDescriptors = NULL;
   memset(&_hardwareRenderCallback, 0, sizeof(_hardwareRenderCallback));
@@ -1188,6 +1199,12 @@ bool libretro::Core::setSupportAchievements(bool data)
   return true;
 }
 
+bool libretro::Core::getFastForwarding(bool* data)
+{
+  *data = _config->getFastForwarding();
+  return true;
+}
+
 bool libretro::Core::getInputBitmasks(bool* data)
 {
   // The documentation says the parameter is a [bool * that indicates whether or not the
@@ -1446,6 +1463,10 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
 
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY:
     ret = setCoreOptionsDisplay((const struct retro_core_option_display*)data);
+    break;
+
+  case RETRO_ENVIRONMENT_GET_FASTFORWARDING:
+    ret = getFastForwarding((bool*)data);
     break;
 
   default:

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -153,6 +153,7 @@ namespace libretro
     bool getUsername(const char** data) const;
     bool getLanguage(unsigned* data) const;
     bool setSupportAchievements(bool data);
+    bool getFastForwarding(bool* data);
     bool getInputBitmasks(bool* data);
     bool getCoreOptionsVersion(unsigned* data) const;
     bool setCoreOptions(const struct retro_core_option_definition* data);
@@ -202,6 +203,7 @@ namespace libretro
     enum retro_pixel_format         _pixelFormat;
     bool                            _supportsNoGame;
     bool                            _supportAchievements;
+    bool                            _fastForwarding;
     
     unsigned                        _inputDescriptorsCount;
     struct retro_input_descriptor*  _inputDescriptors;


### PR DESCRIPTION
Whether or not fast forwarding is currently enabled is now stored in the `Config` object so it can be polled by the core. The `GameTurbo` state has been eliminated. It's now handled within the `GameRunning` state. This has the benefit of remembering if turbo was enabled when transitioning through other states (like opening/closing the overlay).