### PR TITLE
fix interaction of Show Overlay and Pause toggle behaviors

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2067,11 +2067,11 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       break;
 
     case IDM_PAUSE_GAME:
-      _fsm.pauseGame();
+      pauseGame(true);
       break;
 
     case IDM_RESUME_GAME:
-      _fsm.resumeGame();
+      pauseGame(false);
       break;
     
     case IDM_TURBO_GAME:
@@ -2307,31 +2307,35 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
     _fsm.step();
     break;
 
-  case KeyBinds::Action::kPauseToggle:
+  case KeyBinds::Action::kPauseToggle: /* overlay toggle */
     if (_fsm.currentState() == Fsm::State::GamePaused)
     {
-      _fsm.resumeGame();
-      RA_SetPaused(false);
-    }
-    else if (_fsm.currentState() == Fsm::State::GamePausedNoOvl)
-    {
-      _fsm.resumeGame();
+      // overlay visible. hide and unpause
+      pauseGame(false);
     }
     else
     {
+      // paused without overlay, or not paused - show overlay and pause
       _fsm.pauseGame();
       RA_SetPaused(true);
     }
 
     break;
 
-  case KeyBinds::Action::kPauseToggleNoOvl:
+  case KeyBinds::Action::kPauseToggleNoOvl: /* non-overlay pause toggle */
     if (_fsm.currentState() == Fsm::State::GamePausedNoOvl)
     {
+      // paused without overlay, just unpause
       _fsm.resumeGame();
+    }
+    else if (_fsm.currentState() == Fsm::State::GamePaused)
+    {
+      // overlay visible. hide and unpause
+      pauseGame(false);
     }
     else
     {
+      // not paused, pause without overlay (will fail silently in hardcore)
       _fsm.pauseGameNoOvl();
     }
 

--- a/src/Fsm.cpp
+++ b/src/Fsm.cpp
@@ -380,6 +380,34 @@ bool Fsm::loadGame(const_string path) {
 
 bool Fsm::pauseGame() {
   switch (__state) {
+    case State::GamePausedNoOvl: {
+      if (!before()) {
+#ifdef DEBUG_FSM
+        ctx.printf("FSM %s:%u Failed global precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
+#endif
+
+        return false;
+      }
+
+      if (!before(__state)) {
+#ifdef DEBUG_FSM
+        ctx.printf("FSM %s:%u Failed state precondition while switching to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
+#endif
+
+        return false;
+      }
+
+      __state = State::GamePaused;
+      after(__state);
+      after();
+
+#ifdef DEBUG_FSM
+      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GamePaused));
+#endif
+      return true;
+    }
+    break;
+
     case State::GameRunning: {
       if (!before()) {
 #ifdef DEBUG_FSM

--- a/src/Fsm.fsm
+++ b/src/Fsm.fsm
@@ -151,6 +151,8 @@ fsm Fsm {
   }
 
   GamePausedNoOvl {
+    pauseGame() => GamePaused;
+
     resumeGame() => GameRunning;
 
     resetGame() => resumeGame() => resetGame();


### PR DESCRIPTION
Ensures the overlay is shown/hidden correctly when using the Pause toggle button/menu options.

not paused
* pause toggle -> pause if not hardcore, ignore if hardcore
* overlay toggle -> pause and show overlay
* pause menu -> pause if not hardcore, pause and show overlay if hardcore
* resume menu -> not available

paused (not available in hardcore)
* pause toggle -> unpause
* overlay toggle -> show overlay
  * Note: because the overlay toggle switches to overlay mode when toggling the overlay while paused, toggling the overlay again will both close the overlay and resume gameplay (instead of returning to paused mode).
* pause menu -> not available
* resume menu -> unpause

overlay visible
* pause toggle -> unpause and hide overlay
* overlay toggle -> unpause and hide overlay
* pause menu -> not available
* resume menu -> unpause and hide overlay

