### PR TITLE
allow all controllers to be selected in core config dialog

### DIFF
--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -390,7 +390,7 @@ void Config::showDialog(const std::string& coreName, Input& input)
 
   std::vector<Variable*> variables;
   std::vector<int> selections;
-  Variable controllerVariables[2];
+  Variable controllerVariables[4];
 
   for (unsigned i = sizeof(controllerVariables) / sizeof(controllerVariables[0]); i > 0; --i)
   {

--- a/src/components/Input.cpp
+++ b/src/components/Input.cpp
@@ -352,12 +352,10 @@ void Input::setInputDescriptors(const struct retro_input_descriptor* descs, unsi
 void Input::setControllerInfo(const struct retro_controller_info* rinfo, unsigned count)
 {
   ControllerInfo none;
-  memset(&none, 0, sizeof(none));
   none._description = "None";
   none._id = RETRO_DEVICE_NONE;
 
   ControllerInfo retropad;
-  memset(&retropad, 0, sizeof(retropad));
   retropad._description = "RetroPad";
   retropad._id = RETRO_DEVICE_JOYPAD;
 
@@ -380,16 +378,11 @@ void Input::setControllerInfo(const struct retro_controller_info* rinfo, unsigne
         }
 
         ControllerInfo info;
-        memset(&info, 0, sizeof(info));
-        info._description = rinfo->types[i].desc;
+        info._description.assign(rinfo->types[i].desc);
         info._id = rinfo->types[i].id;
 
-        if ((info._id & RETRO_DEVICE_MASK) == RETRO_DEVICE_JOYPAD ||
-          (info._id & RETRO_DEVICE_MASK) == RETRO_DEVICE_ANALOG)
-        {
-          _info[port].push_back(info);
-          _ports |= 1ULL << port;
-        }
+        _info[port].push_back(info);
+        _ports |= 1ULL << port;
       }
     }
 

--- a/src/components/Input.h
+++ b/src/components/Input.h
@@ -127,9 +127,9 @@ protected:
   struct ControllerInfo
   {
     std::string _description;
-    unsigned    _id;
-    int16_t     _state;
-    int16_t     _axis[4];
+    unsigned    _id = 0;
+    int16_t     _state = 0;
+    int16_t     _axis[4] = { 0,0,0,0 };
   };
 
   struct MouseInfo


### PR DESCRIPTION
Fixes #241 

The core settings dialog was filtering the input selections to JOYPAD and ANALOG, as those were originally the only things RALibretro supported. When MOUSE and KEYBOARD were added, the filter was not updated.

While this change does allow selecting the Mouse as an input device, the libretro mouse interface uses relative positions, which means the in-game pointer won't line up exactly with the Windows pointer, so the experience of actually using the mouse for an input device is kind of clunky. We recommend players use the "touch" pointer type in the NDS cores because it uses absolute positions and provides a much better experience. The Beetle PSX core doesn't seem to have a "touch" or "pointer" mouse mode, though it does have a "touch" gun mode.