### PR TITLE
enable Beetle Lynx as a supported core for Atari Lynx

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -336,8 +336,7 @@
   },
   "mednafen_lynx_libretro":{
     "name": "Beetle Lynx",
-    "systems": [13],
-    "platforms": "none"
+    "systems": [13]
   },
   "mednafen_ngp_libretro":{
     "name": "Beetle NeoPop",


### PR DESCRIPTION
Closes #92 

Tested with a headered rom. It was correctly identified, and the core seems to support all the other requirements. 