### PR TITLE
capture and report core errors when loading game

### DIFF
--- a/src/About.cpp
+++ b/src/About.cpp
@@ -31,7 +31,7 @@ void aboutDialog(const char* log)
 
   WORD y = 0;
 
-  db.addLabel("RALibretro \u00A9 2017-2018 Andre Leiradella @leiradel", 0, y, WIDTH, 8);
+  db.addLabel("RALibretro \u00A9 2017-2020 Andre Leiradella @leiradel", 0, y, WIDTH, 8);
   y += LINE;
 
   db.addEditbox(40000, 0, y, WIDTH, LINE, 12, (char*)log, 0, true);

--- a/src/About.cpp
+++ b/src/About.cpp
@@ -31,7 +31,7 @@ void aboutDialog(const char* log)
 
   WORD y = 0;
 
-  db.addLabel("RALibretro \u00A9 2017-2020 Andre Leiradella @leiradel", 0, y, WIDTH, 8);
+  db.addLabel("RALibretro \u00A9 2017-2020 RetroAchievements", 0, y, WIDTH, 8);
   y += LINE;
 
   db.addEditbox(40000, 0, y, WIDTH, LINE, 12, (char*)log, 0, true);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1171,18 +1171,19 @@ bool Application::loadGame(const std::string& path)
   /* must update save path before loading the game */
   _states.setGame(unzippedFileName, _system, _coreName, &_core);
 
+  std::string errorBuffer;
   if (info->need_fullpath)
   {
-    loaded = _core.loadGame(path.c_str(), NULL, 0);
+    loaded = _core.loadGame(path.c_str(), NULL, 0, &errorBuffer);
   }
   else if (iszip)
   {
     std::string zipPsuedoPath = path + '#' + unzippedFileName;
-    loaded = _core.loadGame(zipPsuedoPath.c_str(), data, size);
+    loaded = _core.loadGame(zipPsuedoPath.c_str(), data, size, &errorBuffer);
   }
   else
   {
-    loaded = _core.loadGame(path.c_str(), data, size);
+    loaded = _core.loadGame(path.c_str(), data, size, &errorBuffer);
   }
 
   if (!loaded)
@@ -1190,7 +1191,15 @@ bool Application::loadGame(const std::string& path)
     // The most common cause of failure is missing system files.
     _logger.debug(TAG "Game load failure (%s)", info ? info->library_name : "Unknown");
 
-    MessageBox(g_mainWindow, "Game load error. Please ensure that required system files are present and restart.", "Core Error", MB_OK);
+    if (!errorBuffer.empty())
+    {
+      errorBuffer = "Game load error.\n\n" + errorBuffer;
+      MessageBox(g_mainWindow, errorBuffer.c_str(), "Core Error", MB_OK);
+    }
+    else
+    {
+      MessageBox(g_mainWindow, "Game load error.\n\nPlease ensure that required system files are present and restart.", "Core Error", MB_OK);
+    }
 
     if (data)
     {

--- a/src/RAHasher.cpp
+++ b/src/RAHasher.cpp
@@ -32,9 +32,15 @@ public:
 
     // don't print the category
     while (*line && *line != ']')
+    {
       ++line;
+      --length;
+    }
     while (*line == ']' || *line == ' ')
+    {
       ++line;
+      --length;
+    }
 
     ::fwrite(line, length, 1, stderr);
     ::fprintf(stderr, "\n");

--- a/src/RAHasher.cpp
+++ b/src/RAHasher.cpp
@@ -24,19 +24,19 @@ static void usage(const char* appname)
 class StdErrLogger : public Logger
 {
 public:
-  void vprintf(enum retro_log_level level, const char* fmt, va_list args) override
+  void log(enum retro_log_level level, const char* line, size_t length) override
   {
     // ignore non-errors unless they're coming from the hashing code
-    if (level != RETRO_LOG_ERROR && strncmp(fmt, "[HASH]", 6) != 0)
+    if (level != RETRO_LOG_ERROR && strncmp(line, "[HASH]", 6) != 0)
       return;
 
     // don't print the category
-    while (*fmt && *fmt != ']')
-      ++fmt;
-    while (*fmt == ']' || *fmt == ' ')
-      ++fmt;
+    while (*line && *line != ']')
+      ++line;
+    while (*line == ']' || *line == ' ')
+      ++line;
 
-    ::vfprintf(stderr, fmt, args);
+    ::fwrite(line, length, 1, stderr);
     ::fprintf(stderr, "\n");
   }
 };

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -73,16 +73,12 @@ void Logger::log(enum retro_log_level level, const char* line, size_t length)
   if (level != RETRO_LOG_DEBUG)
   {
     // Log to the internal buffer.
-
-    if (length > sizeof(line))
-    {
-      // Line size too small, truncated. Consider increasing the array size.
-      length = sizeof(line);
-    }
-
     length += 3; // Add one byte for the level and two bytes for the length.
-    unsigned char meta[3];
 
+    if (length > RING_LOG_MAX_LINE_SIZE)
+      length = RING_LOG_MAX_LINE_SIZE;
+
+    unsigned char meta[3];
     if (length > _avail)
     {
       do
@@ -103,7 +99,6 @@ void Logger::log(enum retro_log_level level, const char* line, size_t length)
     write(line, length);
 
     // Log to the console.
-
     ::printf("[%s] %s\n", desc, line);
     fflush(stdout);
   }

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -21,6 +21,11 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <memory.h>
 
+/* must be less than RING_LOG_MAX_BUFFER_SIZE */
+#ifndef RING_LOG_MAX_LINE_SIZE
+#define RING_LOG_MAX_LINE_SIZE 1024
+#endif
+
 bool Logger::init()
 {
   // Do compile-time checks for the line and buffer sizes.
@@ -51,22 +56,8 @@ void Logger::destroy()
 #endif
 }
 
-void Logger::vprintf(enum retro_log_level level, const char* fmt, va_list args)
+void Logger::log(enum retro_log_level level, const char* line, size_t length)
 {
-  char line[RING_LOG_MAX_LINE_SIZE];
-  size_t length = vsnprintf(line, sizeof(line), fmt, args);
-
-  if (length >= sizeof(line))
-  {
-    length = sizeof(line) - 1;
-    line[length - 1] = line[length - 2] = line[length - 3] = '.';
-  }
-
-  while (length > 0 && line[length - 1] == '\n')
-  {
-    line[--length] = 0;
-  }
-
   const char* desc = "?";
 
   switch (level)

--- a/src/components/Logger.h
+++ b/src/components/Logger.h
@@ -25,11 +25,6 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #endif
 
-// Must be at most 65535
-#ifndef RING_LOG_MAX_LINE_SIZE
-#define RING_LOG_MAX_LINE_SIZE 1024
-#endif
-
 // Must be at least MAX_LINE_SIZE + 3
 #ifndef RING_LOG_MAX_BUFFER_SIZE
 #define RING_LOG_MAX_BUFFER_SIZE 65536
@@ -41,14 +36,14 @@ public:
   bool init();
   void destroy();
 
-  virtual void vprintf(enum retro_log_level level, const char* fmt, va_list args) override;
-
   std::string contents() const;
   
   typedef bool (*Iterator)(enum retro_log_level level, const char* line, void* ud);
   void iterate(Iterator iterator, void* ud) const;
 
 protected:
+  void   log(enum retro_log_level level, const char* msg, size_t length) override;
+
   void   write(const void* data, size_t size);
   void   read(void* data, size_t size);
   size_t peek(size_t pos, void* data, size_t size) const;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -30,6 +30,10 @@ SOFTWARE.
 
 #include "libretro.h"
 
+#ifndef LOG_MAX_LINE_SIZE
+#define LOG_MAX_LINE_SIZE 1024
+#endif
+
 namespace libretro
 {
   /**
@@ -38,7 +42,26 @@ namespace libretro
   class LoggerComponent
   {
   public:
-    virtual void vprintf(enum retro_log_level level, const char* fmt, va_list args) = 0;
+    virtual void log(enum retro_log_level level, const char* line, size_t length) = 0;
+
+    void vprintf(enum retro_log_level level, const char* fmt, va_list args)
+    {
+      char line[LOG_MAX_LINE_SIZE];
+      size_t length = vsnprintf(line, sizeof(line), fmt, args);
+
+      if (length >= sizeof(line))
+      {
+        length = sizeof(line) - 1;
+        line[length - 1] = line[length - 2] = line[length - 3] = '.';
+      }
+
+      while (length > 0 && line[length - 1] == '\n')
+      {
+        line[--length] = 0;
+      }
+
+      log(level, line, length);
+    }
 
     void setLogLevel(enum retro_log_level level)
     {

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -40,7 +40,7 @@ namespace libretro
     bool init(const Components* components);
     bool loadCore(const char* core_path);
     bool initCore();
-    bool loadGame(const char* game_path, void* data, size_t size);
+    bool loadGame(const char* game_path, void* data, size_t size, std::string* errorBuffer);
 
     void destroy();
     


### PR DESCRIPTION
Any errors logged by the core while loading a game will now be reported in the "Game load error" dialog.

![image](https://user-images.githubusercontent.com/32680403/99282738-51541a80-27f1-11eb-8d89-e24466f04d77.png)

If no errors are logged, the existing dialog will be shown with a generic "Please ensure that required system files are present and restart." message.