### PR TITLE
disable hardcore mode when certain core options are enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ OBJS=\
 	src/libretro/Core.o \
 	src/RA_Implementation.o \
 	src/RAInterface/RA_Interface.o \
+	src/cheevos_libretro.o \
 	src/components/Audio.o \
 	src/components/Config.o \
 	src/components/Dialog.o \
@@ -91,6 +92,8 @@ OBJS=\
 	src/menu.res \
 	src/States.o \
 	src/Util.o
+
+src/cheevos_libretro.o: CFLAGS += -I./src/libretro
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -293,6 +293,7 @@ bool Application::init(const char* title, int width, int height)
   _coreName.clear();
   _validSlots = 0;
   lastHardcore = hardcore();
+  cancelLoad = false;
   updateMenu();
   updateCDMenu(NULL, 0, true);
   return true;
@@ -806,7 +807,7 @@ void Application::run()
       }
     } while (true);
   }
-  catch (std::exception ex) {
+  catch (std::exception& ex) {
     _logger.error(TAG "Unhandled exception: %s", ex.what());
   }
 }
@@ -1003,6 +1004,35 @@ bool Application::loadCore(const std::string& coreName)
   return true;
 }
 
+bool Application::validateHardcoreEnablement()
+{
+  if (_config.validateSettingsForHardcore(_core.getSystemInfo()->library_name, false))
+    return true;
+
+#if defined(MINGW) || defined(__MINGW32__) || defined(__MINGW64__)
+  RA_DisableHardcore();
+#else
+  __try
+  {
+    // This functionality is not available in the 0.78 DLL, but is implemented in such a way that
+    // it throws an exception we can catch and handle.
+    RA_DisableHardcore();
+  }
+  __except (EXCEPTION_EXECUTE_HANDLER)
+  {
+    MessageBox(g_mainWindow, "Could not prevent switch to hardcore. Closing game.", "Failed", MB_OK);
+
+    // if this gets called during the load (auto-enable hardcore when achievements are present), the
+    // FSM won't transition properly. set a flag so we can deal with it when we get done loading.
+    cancelLoad = true;
+
+    _fsm.unloadGame();
+  }
+#endif
+
+  return false;
+}
+
 void Application::updateMenu()
 {
   static const UINT all_items[] =
@@ -1092,6 +1122,16 @@ bool Application::loadGame(const std::string& path)
   bool loaded;
   bool iszip = (path.length() > 4 && stricmp(&path.at(path.length() - 4), ".zip") == 0);
   bool issupportedzip = false;
+
+  /* in hardcore mode, make sure none of the forbidden settings are set */
+  if (RA_HardcoreModeIsActive())
+  {
+    if (!_config.validateSettingsForHardcore(_core.getSystemInfo()->library_name, true))
+    {
+      MessageBox(g_mainWindow, "Game load was canceled.", "Failed", MB_OK);
+      return false;
+    }
+  }
 
   /* if the core says it wants the full path, we have to see if it supports zip files */
   if (iszip && info->need_fullpath)
@@ -1193,15 +1233,28 @@ bool Application::loadGame(const std::string& path)
     MessageBox(g_mainWindow, "Game load error. Please ensure that required system files are present and restart.", "Core Error", MB_OK);
 
     if (data)
-    {
       free(data);
-    }
 
     // A failure in loadGame typically destroys the core.
     if (_core.getSystemInfo()->library_name == NULL)
       _fsm.unloadCore();
 
     return false;
+  }
+
+  /* calling loadGame may change one or more settings - revalidate */
+  if (RA_HardcoreModeIsActive())
+  {
+    if (!_config.validateSettingsForHardcore(_core.getSystemInfo()->library_name, true))
+    {
+      if (data)
+        free(data);
+
+      _core.unloadGame();
+
+      MessageBox(g_mainWindow, "Game load was canceled.", "Failed", MB_OK);
+      return false;
+    }
   }
 
   RA_SetConsoleID((unsigned)_system);
@@ -1218,16 +1271,20 @@ bool Application::loadGame(const std::string& path)
     _core.unloadGame();
 
     if (data)
-    {
       free(data);
-    }
 
     return false;
   }
 
   if (data)
-  {
     free(data);
+
+  if (cancelLoad)
+  {
+    cancelLoad = false; // reset for future load attempts
+
+    _fsm.unloadGame();
+    return false;
   }
 
   // reset the vertical sync flag
@@ -1335,10 +1392,10 @@ bool Application::hardcore()
 
 bool Application::unloadGame()
 {
+  cancelLoad = false; // reset for future loads
+
   if (!RA_ConfirmLoadNewRom(true))
-  {
     return false;
-  }
 
   _states.saveSRAM(&_core);
 

--- a/src/Application.h
+++ b/src/Application.h
@@ -66,6 +66,7 @@ public:
   // RA_Integration
   bool isGameActive();
   const std::string& gameName() const { return _gameFileName; }
+  bool validateHardcoreEnablement();
 
   void onRotationChanged(Video::Rotation oldRotation, Video::Rotation newRotation);
 
@@ -118,6 +119,7 @@ protected:
 
   Fsm _fsm;
   bool lastHardcore;
+  bool cancelLoad;
 
   std::string _coreName;
   int         _system;

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -219,6 +219,12 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     <ClCompile Include="About.cpp" />
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="CdRom.cpp" />
+    <ClCompile Include="cheevos_libretro.c">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)libretro;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)libretro;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)libretro;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)libretro;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
     <ClCompile Include="components\Audio.cpp" />
     <ClCompile Include="components\Config.cpp" />
     <ClCompile Include="components\Dialog.cpp" />

--- a/src/RALibretro.vcxproj.filters
+++ b/src/RALibretro.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClCompile Include="States.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cheevos_libretro.c">
+      <Filter>Source Files\RAInterface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="About.h">

--- a/src/cheevos_libretro.c
+++ b/src/cheevos_libretro.c
@@ -1,0 +1,161 @@
+/* This file provides a series of functions for integrating RetroAchievements with libretro.
+ * These functions will be called by a libretro frontend to validate certain expected behaviors
+ * and simplify mapping core data to the RAIntegration DLL.
+ * 
+ * Originally designed to be shared between RALibretro and RetroArch, but will simplify
+ * integrating with any other frontends.
+ */
+
+#include "cheevos_libretro.h"
+
+/* this file comes from the libretro repository, which is not an explicit submodule.
+ * the integration must set up paths appropriately to find it. */
+#include <libretro.h>
+
+#include <ctype.h>
+#include <string.h>
+
+typedef struct rc_disallowed_core_settings_t
+{
+  const char* library_name;
+  const rc_disallowed_setting_t* disallowed_settings;
+} rc_disallowed_core_settings_t;
+
+static const rc_disallowed_setting_t _rc_disallowed_dolphin_settings[] = {
+  { "dolphin_cheats_enabled", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_ecwolf_settings[] = {
+  { "ecwolf-invulnerability", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_fbneo_settings[] = {
+  { "fbneo-allow-patched-romsets", "enabled" },
+  { "fbneo-cheat-*", "!,Disabled,0 - Disabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_gpgx_settings[] = {
+  { "genesis_plus_gx_lock_on", ",action replay (pro),game genie" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_ppsspp_settings[] = {
+  { "ppsspp_cheats", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_core_settings_t rc_disallowed_core_settings[] = {
+  { "dolphin-emu", _rc_disallowed_dolphin_settings },
+  { "ecwolf", _rc_disallowed_ecwolf_settings },
+  { "FinalBurn Neo", _rc_disallowed_fbneo_settings },
+  { "Genesis Plus GX", _rc_disallowed_gpgx_settings },
+  { "PPSSPP", _rc_disallowed_ppsspp_settings },
+  { NULL, NULL }
+};
+
+static int rc_libretro_string_equal_nocase(const char* test, const char* value)
+{
+  while (*test)
+  {
+    if (tolower(*test++) != tolower(*value++))
+      return 0;
+  }
+
+  return (*value == '\0');
+}
+
+static int rc_libretro_match_value(const char* val, const char* match)
+{
+  /* if value starts with a comma, it's a CSV list of potential matches */
+  if (*match == ',')
+  {
+    do
+    {
+      const char* ptr = ++match;
+      int size;
+
+      while (*match && *match != ',')
+        ++match;
+
+      size = match - ptr;
+      if (val[size] == '\0')
+      {
+        if (memcmp(ptr, val, size) == 0)
+        {
+          return true;
+        }
+        else
+        {
+          char buffer[128];
+          memcpy(buffer, ptr, size);
+          buffer[size] = '\0';
+          if (rc_libretro_string_equal_nocase(buffer, val))
+            return true;
+        }
+      }
+    } while (*match == ',');
+
+    return false;
+  }
+
+  /* a leading exclamation point means the provided value(s) are not forbidden (are allowed) */
+  if (*match == '!')
+    return !rc_libretro_match_value(val, &match[1]);
+
+  /* just a single value, attempt to match it */
+  return rc_libretro_string_equal_nocase(val, match);
+}
+
+int rc_libretro_is_setting_allowed(const rc_disallowed_setting_t* disallowed_settings, const char* setting, const char* value)
+{
+  const char* key;
+  size_t key_len;
+
+  for (; disallowed_settings->setting; ++disallowed_settings)
+  {
+    key = disallowed_settings->setting;
+    key_len = strlen(key);
+
+    if (key[key_len - 1] == '*')
+    {
+      if (memcmp(setting, key, key_len - 1) == 0)
+      {
+        if (rc_libretro_match_value(value, disallowed_settings->value))
+          return 0;
+      }
+    }
+    else
+    {
+      if (memcmp(setting, key, key_len + 1) == 0)
+      {
+        if (rc_libretro_match_value(value, disallowed_settings->value))
+          return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+const rc_disallowed_setting_t* rc_libretro_get_disallowed_settings(const char* library_name)
+{
+  const rc_disallowed_core_settings_t* core_filter = rc_disallowed_core_settings;
+  size_t library_name_length;
+
+  if (!library_name || !library_name[0])
+    return NULL;
+
+  library_name_length = strlen(library_name) + 1;
+  while (core_filter->library_name)
+  {
+    if (memcmp(core_filter->library_name, library_name, library_name_length) == 0)
+      return core_filter->disallowed_settings;
+
+    ++core_filter;
+  }
+
+  return NULL;
+}

--- a/src/cheevos_libretro.h
+++ b/src/cheevos_libretro.h
@@ -1,0 +1,21 @@
+#ifndef CHEEVOS_LIBRETRO_H
+#define CHEEVOS_LIBRETRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct rc_disallowed_setting_t
+{
+  const char* setting;
+  const char* value;
+} rc_disallowed_setting_t;
+
+const rc_disallowed_setting_t* rc_libretro_get_disallowed_settings(const char* library_name);
+int rc_libretro_is_setting_allowed(const rc_disallowed_setting_t* disallowed_settings, const char* setting, const char* value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CHEEVOS_LIBRETRO_H */

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -63,6 +63,8 @@ public:
   std::string serialize();
   void deserialize(const char* json);
 
+  bool validateSettingsForHardcore(const char* library_name, bool prompt) const;
+
 #ifdef _WINDOWS
   void showDialog(const std::string& coreName, Input& input);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,9 @@ void resume()
 
 void reset()
 {
-  app.resetGame();
+  // this is called when the user switches from non-hardcore to hardcore - validate the config settings
+  if (app.validateHardcoreEnablement())
+    app.resetGame();
 }
 
 void loadROM(const char* path)


### PR DESCRIPTION
Adds validation checks for unapproved core settings when loading a game, when changing core settings, and when enabling hardcore mode.

Similar changes were made in RetroArch via https://github.com/libretro/RetroArch/pull/11476