### PR TITLE
calculate root folder before opening log file

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -95,7 +95,9 @@ bool Application::init(const char* title, int width, int height)
   }
   inited = kNothingInited;
 
-  if (!_logger.init())
+  _config.initRootFolder();
+
+  if (!_logger.init(_config.getRootFolder()))
   {
     goto error;
   }

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -37,17 +37,17 @@ extern HWND g_mainWindow;
 
 #define TAG "[CFG] "
 
-bool Config::init(libretro::LoggerComponent* logger)
+void Config::initRootFolder()
 {
-  _logger = logger;
-
 #ifdef _WINDOWS
-  HMODULE hModule = GetModuleHandleW(NULL);
   WCHAR path[MAX_PATH + 1];
-  DWORD len = GetModuleFileNameW(hModule, path, sizeof(path) / sizeof(path[0]) - 1);
+  DWORD len = GetModuleFileNameW(NULL, path, MAX_PATH);
   path[len] = 0;
 
-  _rootFolder = util::ucharToUtf8(path);
+  WCHAR fullpath[MAX_PATH + 1];
+  len = GetFullPathNameW(path, MAX_PATH, fullpath, NULL);
+
+  _rootFolder = util::ucharToUtf8(fullpath);
 #endif
 
   size_t index = _rootFolder.find_last_of('\\');
@@ -59,6 +59,11 @@ bool Config::init(libretro::LoggerComponent* logger)
   {
     _rootFolder = ".\\";
   }
+}
+
+bool Config::init(libretro::LoggerComponent* logger)
+{
+  _logger = logger;
 
   _assetsFolder = _rootFolder + "Assets\\";
   _saveFolder = _rootFolder + "Saves\\";

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -31,6 +31,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 class Config: public libretro::ConfigComponent
 {
 public:
+  void initRootFolder();
   bool init(libretro::LoggerComponent* logger);
   void destroy() {}
   void reset();

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -26,7 +26,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #define RING_LOG_MAX_LINE_SIZE 1024
 #endif
 
-bool Logger::init()
+bool Logger::init(const char* rootFolder)
 {
   // Do compile-time checks for the line and buffer sizes.
   char check_line_size[RING_LOG_MAX_LINE_SIZE <= 65535 ? 1 : -1];
@@ -39,7 +39,11 @@ bool Logger::init()
   _first = _last = 0;
 
 #ifdef LOG_TO_FILE
-  _file = fopen("log.txt", "w");
+  char path[512] = "";
+  if (rootFolder)
+    strcpy(path, rootFolder);
+  strcat(path, "log.txt");
+  _file = fopen(path, "w");
 #endif
 
 #ifndef NDEBUG

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -20,6 +20,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #include "Logger.h"
 
 #include <memory.h>
+#include <string.h>
 
 /* must be less than RING_LOG_MAX_BUFFER_SIZE */
 #ifndef RING_LOG_MAX_LINE_SIZE

--- a/src/components/Logger.h
+++ b/src/components/Logger.h
@@ -33,7 +33,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 class Logger: public libretro::LoggerComponent
 {
 public:
-  bool init();
+  bool init(const char* rootFolder);
   void destroy();
 
   std::string contents() const;


### PR DESCRIPTION
supports #253

The log file was being opened before calculating the root folder. I've modified the logic to calculate the root folder first, and write the log fie there.