### PR TITLE
register invalid banks without a read function

### DIFF
--- a/src/Memory.h
+++ b/src/Memory.h
@@ -38,6 +38,7 @@ protected:
   void initializeWithoutRegions(libretro::Core* core);
   void initializeFromMemoryMap(const rc_memory_regions_t* regions, const retro_memory_map* mmap);
   void initializeFromUnmappedMemory(const rc_memory_regions_t* regions, libretro::Core* core);
+  void installMemoryBanks();
 
   libretro::LoggerComponent* _logger;
 };


### PR DESCRIPTION
supports display of unsupported memory regions (see https://github.com/RetroAchievements/RAIntegration/pull/669)