### PR TITLE
addresses passed to read/write functions are relative to the start of the bank

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -31,13 +31,14 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 #define MAX_MEMORY_REGIONS 64
 static uint8_t* g_memoryRegionData[MAX_MEMORY_REGIONS];
 static size_t g_memoryRegionSize[MAX_MEMORY_REGIONS];
+static int g_memoryBankFirstRegion[16];
 static unsigned g_memoryRegionCount = 0;
 static size_t g_memoryTotalSize = 0;
 
-static unsigned char memoryRead(unsigned addr)
+static unsigned char memoryRead(unsigned addr, int firstRegion)
 {
   unsigned i;
-  for (i = 0; i < g_memoryRegionCount; ++i)
+  for (i = firstRegion; i < g_memoryRegionCount; ++i)
   {
     const size_t size = g_memoryRegionSize[i];
     if (addr < size)
@@ -54,10 +55,10 @@ static unsigned char memoryRead(unsigned addr)
   return 0;
 }
 
-static void memoryWrite(unsigned addr, unsigned char value)
+static void memoryWrite(unsigned addr, int firstRegion, unsigned char value)
 {
   unsigned i;
-  for (i = 0; i < g_memoryRegionCount; ++i)
+  for (i = firstRegion; i < g_memoryRegionCount; ++i)
   {
     const size_t size = g_memoryRegionSize[i];
     if (addr < size)
@@ -72,6 +73,66 @@ static void memoryWrite(unsigned addr, unsigned char value)
   }
 }
 
+static unsigned char memoryRead0(unsigned addr) { return memoryRead(addr, 0); }
+static unsigned char memoryRead1(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[1]); }
+static unsigned char memoryRead2(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[2]); }
+static unsigned char memoryRead3(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[3]); }
+static unsigned char memoryRead4(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[4]); }
+static unsigned char memoryRead5(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[5]); }
+static unsigned char memoryRead6(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[6]); }
+static unsigned char memoryRead7(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[7]); }
+static unsigned char memoryRead8(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[8]); }
+static unsigned char memoryRead9(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[9]); }
+static unsigned char memoryRead10(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[10]); }
+static unsigned char memoryRead11(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[11]); }
+static unsigned char memoryRead12(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[12]); }
+static unsigned char memoryRead13(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[13]); }
+static unsigned char memoryRead14(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[14]); }
+static unsigned char memoryRead15(unsigned addr) { return memoryRead(addr, g_memoryBankFirstRegion[15]); }
+
+static void memoryWrite0(unsigned addr, unsigned char value) { memoryWrite(addr, 0, value); }
+static void memoryWrite1(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[1], value); }
+static void memoryWrite2(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[2], value); }
+static void memoryWrite3(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[3], value); }
+static void memoryWrite4(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[4], value); }
+static void memoryWrite5(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[5], value); }
+static void memoryWrite6(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[6], value); }
+static void memoryWrite7(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[7], value); }
+static void memoryWrite8(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[8], value); }
+static void memoryWrite9(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[9], value); }
+static void memoryWrite10(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[10], value); }
+static void memoryWrite11(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[11], value); }
+static void memoryWrite12(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[12], value); }
+static void memoryWrite13(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[13], value); }
+static void memoryWrite14(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[14], value); }
+static void memoryWrite15(unsigned addr, unsigned char value) { memoryWrite(addr, g_memoryBankFirstRegion[15], value); }
+
+static void installMemoryBank(int bankId, int validBankId, int firstRegion, size_t bankSize, libretro::LoggerComponent* logger)
+{
+  switch (validBankId)
+  {
+    case 0: RA_InstallMemoryBank(bankId, memoryRead0, memoryWrite0, bankSize); break;
+    case 1: RA_InstallMemoryBank(bankId, memoryRead1, memoryWrite1, bankSize); break;
+    case 2: RA_InstallMemoryBank(bankId, memoryRead2, memoryWrite2, bankSize); break;
+    case 3: RA_InstallMemoryBank(bankId, memoryRead3, memoryWrite3, bankSize); break;
+    case 4: RA_InstallMemoryBank(bankId, memoryRead4, memoryWrite4, bankSize); break;
+    case 5: RA_InstallMemoryBank(bankId, memoryRead5, memoryWrite5, bankSize); break;
+    case 6: RA_InstallMemoryBank(bankId, memoryRead6, memoryWrite6, bankSize); break;
+    case 7: RA_InstallMemoryBank(bankId, memoryRead7, memoryWrite7, bankSize); break;
+    case 8: RA_InstallMemoryBank(bankId, memoryRead8, memoryWrite8, bankSize); break;
+    case 9: RA_InstallMemoryBank(bankId, memoryRead9, memoryWrite9, bankSize); break;
+    case 10: RA_InstallMemoryBank(bankId, memoryRead10, memoryWrite10, bankSize); break;
+    case 11: RA_InstallMemoryBank(bankId, memoryRead11, memoryWrite11, bankSize); break;
+    case 12: RA_InstallMemoryBank(bankId, memoryRead12, memoryWrite12, bankSize); break;
+    case 13: RA_InstallMemoryBank(bankId, memoryRead13, memoryWrite13, bankSize); break;
+    case 14: RA_InstallMemoryBank(bankId, memoryRead14, memoryWrite14, bankSize); break;
+    case 15: RA_InstallMemoryBank(bankId, memoryRead15, memoryWrite15, bankSize); break;
+    default: logger->warn(TAG "Too many unsupported memory regions"); return;
+  }
+
+  g_memoryBankFirstRegion[validBankId] = firstRegion;
+}
+
 static clock_t g_lastMemoryRefresh = 0;
 static unsigned char deferredMemoryRead(unsigned addr)
 {
@@ -84,7 +145,7 @@ static unsigned char deferredMemoryRead(unsigned addr)
 
   extern Application app;
   app.refreshMemoryMap();
-  return memoryRead(addr);
+  return memoryRead0(addr);
 }
 
 static const char* getMemoryType(int type)
@@ -205,7 +266,7 @@ void Memory::attachToCore(libretro::Core* core, int consoleId)
   {
     g_lastMemoryRefresh = clock();
     RA_ClearMemoryBanks();
-    RA_InstallMemoryBank(0, deferredMemoryRead, memoryWrite, g_memoryTotalSize);
+    RA_InstallMemoryBank(0, deferredMemoryRead, memoryWrite0, g_memoryTotalSize);
   }
 }
 
@@ -238,12 +299,14 @@ void Memory::installMemoryBanks()
   if (!g_bVersionSupported)
   {
     // have an 0.78 DLL - register a read function that will return 0 for the unsupported regions
-    RA_InstallMemoryBank(0, memoryRead, memoryWrite, g_memoryTotalSize);
+    RA_InstallMemoryBank(0, memoryRead0, memoryWrite0, g_memoryTotalSize);
     return;
   }
 
   // have an 0.79 DLL - register invalid banks for unsupported regions
   int bankId = 0;
+  int validBankId = 0;
+  int firstRegion = 0;
   size_t bankSize = 0;
   bool wasValidRegion = false;
   for (size_t i = 0; i < g_memoryRegionCount; i++)
@@ -252,10 +315,11 @@ void Memory::installMemoryBanks()
     if (bankSize > 0 && isValidRegion != wasValidRegion)
     {
       if (wasValidRegion)
-        RA_InstallMemoryBank(bankId, memoryRead, memoryWrite, bankSize);
+        installMemoryBank(bankId, validBankId++, firstRegion, bankSize, _logger);
       else
         RA_InstallMemoryBank(bankId, NULL, NULL, bankSize);
 
+      firstRegion = i;
       bankSize = g_memoryRegionSize[i];
       ++bankId;
     }
@@ -270,7 +334,7 @@ void Memory::installMemoryBanks()
   if (bankSize > 0)
   {
     if (wasValidRegion)
-      RA_InstallMemoryBank(bankId, memoryRead, memoryWrite, bankSize);
+      installMemoryBank(bankId, validBankId, firstRegion, bankSize, _logger);
     else
       RA_InstallMemoryBank(bankId, NULL, NULL, bankSize);
   }


### PR DESCRIPTION
Changes made for #258 can register multiple banks with the DLL, but all banks were using the same read/write functions, so all memory was coming out of the first bank. The callback functions registered with the DLL are passed an offset within the bank, so the logic has to offset the read/write to accommodate.