### PR TITLE
avoid 100% cpu core use while paused

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -780,6 +780,7 @@ void Application::run()
         case Fsm::State::GamePausedNoOvl:
         default:
           // do no frames
+          Sleep(10);
           break;
 
         case Fsm::State::FrameStep:


### PR DESCRIPTION
When paused, the main loop ran at full speed, using up a whole cpu core.

This commit puts a 10ms sleep into the loop when paused, bringing cpu use down to virtually 0. The sleep duration is small enough for the overlay to be navigable without noticeable delay.