### PR TITLE
Support for RASTATE state files

### DIFF
--- a/src/States.h
+++ b/src/States.h
@@ -89,6 +89,7 @@ private:
   std::string getStatePath(unsigned ndx, Path path, bool bOldFormat) const;
 
   void saveSRAM(void* sramData, size_t sramSize);
+  void restoreFrameBuffer(const void* pixels, unsigned image_width, unsigned image_height, unsigned pitch);
 
   bool loadRAState1(unsigned char* input, size_t size);
 };

--- a/src/States.h
+++ b/src/States.h
@@ -35,7 +35,7 @@ public:
   std::string getSRamPath() const;
   std::string getStatePath(unsigned ndx) const;
 
-  void        saveState(const std::string& path);
+  bool        saveState(const std::string& path);
   void        saveState(unsigned ndx);
   bool        loadState(const std::string& path);
   bool        loadState(unsigned ndx);

--- a/src/States.h
+++ b/src/States.h
@@ -86,7 +86,9 @@ private:
   static Path decodePath(const std::string& shorthand);
 
   std::string getSRamPath(Path path) const;
-  std::string getStatePath(unsigned ndx, Path path) const;
+  std::string getStatePath(unsigned ndx, Path path, bool bOldFormat) const;
 
   void saveSRAM(void* sramData, size_t sramSize);
+
+  bool loadRAState1(unsigned char* input, size_t size);
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -971,6 +971,18 @@ void* util::loadImage(Logger* logger, const std::string& path, unsigned* width, 
   return rgb888;
 }
 
+void* util::fromPng(Logger* logger, const void* data, int len, unsigned* width, unsigned* height, unsigned* pitch)
+{
+  int w, h;
+  void* rgb888 = stbi_load_from_memory((const stbi_uc*)data, len, &w, &h, NULL, STBI_rgb);
+
+  *width = w;
+  *height = h;
+  *pitch = w * 3;
+
+  return rgb888;
+}
+
 #ifdef _WINDOWS
 std::string util::ucharToUtf8(const std::wstring& unicodeString)
 {

--- a/src/Util.h
+++ b/src/Util.h
@@ -84,6 +84,7 @@ namespace util
   const void* toRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void        saveImage(Logger* logger, const std::string& path, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void*       fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format);
+  void*       fromPng(Logger* logger, const void* data, int len, unsigned* width, unsigned* height, unsigned* pitch);
   void*       loadImage(Logger* logger, const std::string& path, unsigned* width, unsigned* height, unsigned* pitch);
 
 #ifdef _WINDOWS

--- a/src/Util.h
+++ b/src/Util.h
@@ -80,6 +80,7 @@ namespace util
   std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter);
 #endif
 
+  const void* toPng(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format, int* len);
   const void* toRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void        saveImage(Logger* logger, const std::string& path, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format);
   void*       fromRgb(Logger* logger, const void* data, unsigned width, unsigned height, unsigned* pitch, enum retro_pixel_format format);


### PR DESCRIPTION
Supports the new save state container format implemented in RetroArch. Allows achievement state to be stored directly in the save state file instead of in a neighboring file. Also allows the frame buffer to be stored in the state file (closes #125).

Legacy formatted files (with their companion .rap and .png files) are still supported. Newly created files will always be in the new format.

Additionally, the filename format has been changed from "GameName.001.state" to "GameName.state1" to match RetroArch, making it easier to share files between them. Existing ".XXX.state" files will still be recognized when loading the built-in states. Saving to a built-in state slots will generate a ".stateX" file and remove the ".XXX.state" files.

RZIP (compresses RetroArch) save states are still not supported.