### PR TITLE
fix opening log file in unicode path

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -134,17 +134,23 @@ FILE* util::openFile(Logger* logger, const std::string& path, const char* mode)
 
   if (err)
   {
-    char buffer[256];
-    strerror_s(buffer, sizeof(buffer), err);
-    logger->error(TAG "Error opening \"%s\": %s", path.c_str(), buffer);
+    if (logger)
+    {
+      char buffer[256];
+      strerror_s(buffer, sizeof(buffer), err);
+      logger->error(TAG "Error opening \"%s\": %s", path.c_str(), buffer);
+    }
     file = NULL;
   }
 #else
   file = fopen(path.c_str(), mode);
   if (errno)
   {
-    char buffer[256];
-    logger->error(TAG "Error opening \"%s\": %s", path.c_str(), strerror_r(errno, buffer, sizeof(buffer)));
+    if (logger)
+    {
+      char buffer[256];
+      logger->error(TAG "Error opening \"%s\": %s", path.c_str(), strerror_r(errno, buffer, sizeof(buffer)));
+    }
     file = NULL;
   }
 #endif

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -61,7 +61,11 @@ bool Logger::init(const char* rootFolder)
 void Logger::destroy()
 {
 #ifdef LOG_TO_FILE
-  fclose(_file);
+  if (_file)
+  {
+    fclose(_file);
+    _file = NULL;
+  }
 #endif
 }
 
@@ -113,11 +117,14 @@ void Logger::log(enum retro_log_level level, const char* line, size_t length)
   }
 
 #ifdef LOG_TO_FILE
-  // Log to the log file.
-  fprintf(_file, "[%s] %s\n", desc, line);
+  if (_file)
+  {
+    // Log to the log file.
+    fprintf(_file, "[%s] %s\n", desc, line);
 #ifndef NDEBUG
-  fflush(_file);
+    fflush(_file);
 #endif
+  }
 #endif
 }
 

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -19,6 +19,10 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Logger.h"
 
+#ifdef LOG_TO_FILE
+#include "Util.h"
+#endif
+
 #include <memory.h>
 #include <string.h>
 
@@ -44,7 +48,7 @@ bool Logger::init(const char* rootFolder)
   if (rootFolder)
     strcpy(path, rootFolder);
   strcat(path, "log.txt");
-  _file = fopen(path, "w");
+  _file = util::openFile(NULL, path, "w");
 #endif
 
 #ifndef NDEBUG


### PR DESCRIPTION
fixes a bug introduced by #256 where the log could not be opened if run from within a path containing non-ASCII characters.