### PR TITLE
add QuickNES as a supported core

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -545,8 +545,7 @@
   },
   "quicknes_libretro":{
     "name": "QuickNES",
-    "systems": [7],
-    "platforms": "none"
+    "systems": [7]
   },
   "race_libretro":{
     "name": "RACE",


### PR DESCRIPTION
closes #78 