### PR TITLE
make video settings global

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -869,6 +869,10 @@ void Application::saveConfiguration()
     json += "}";
   }
 
+  // video settings
+  json.append(",\"video\":");
+  json.append(_video.serializeSettings());
+
   // complete and save
   json += "}";
 
@@ -969,10 +973,6 @@ bool Application::loadCore(const std::string& coreName)
         {
           ud->self->_input.deserialize(str);
         }
-        else if (ud->key == "video")
-        {
-          ud->self->_video.deserialize(str);
-        }
       }
 
       return 0;
@@ -1046,7 +1046,7 @@ void Application::updateMenu()
     IDM_PAUSE_GAME, IDM_RESUME_GAME, IDM_RESET_GAME,
     IDM_EXIT,
 
-    IDM_CORE_CONFIG, IDM_VIDEO_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
+    IDM_CORE_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
   };
 
   static const UINT start_items[] =
@@ -1056,7 +1056,7 @@ void Application::updateMenu()
 
   static const UINT core_loaded_items[] =
   {
-    IDM_LOAD_GAME, IDM_EXIT, IDM_CORE_CONFIG, IDM_VIDEO_CONFIG, IDM_ABOUT
+    IDM_LOAD_GAME, IDM_EXIT, IDM_CORE_CONFIG, IDM_ABOUT
   };
 
   static const UINT game_running_items[] =
@@ -1064,7 +1064,7 @@ void Application::updateMenu()
     IDM_LOAD_GAME, IDM_PAUSE_GAME, IDM_RESET_GAME,
     IDM_EXIT,
 
-    IDM_CORE_CONFIG, IDM_VIDEO_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
+    IDM_CORE_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
   };
 
   static const UINT game_paused_items[] =
@@ -1072,7 +1072,7 @@ void Application::updateMenu()
     IDM_LOAD_GAME, IDM_RESUME_GAME, IDM_RESET_GAME,
     IDM_EXIT,
 
-    IDM_CORE_CONFIG, IDM_VIDEO_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
+    IDM_CORE_CONFIG, IDM_TURBO_GAME, IDM_ABOUT
   };
 
   enableItems(all_items, sizeof(all_items) / sizeof(all_items[0]), MF_DISABLED);
@@ -1375,8 +1375,6 @@ void Application::unloadCore()
   json.append(_config.serialize());
   json.append(",\"input\":");
   json.append(_input.serialize());
-  json.append(",\"video\":");
-  json.append(_video.serialize());
   json.append("}");
 
   util::saveFile(&_logger, getCoreConfigPath(_coreName), json.c_str(), json.length());
@@ -2021,6 +2019,13 @@ void Application::loadConfiguration()
       else if (ud->key == "saves" && event == JSONSAX_OBJECT)
       {
         if (!ud->self->_states.deserializeSettings(str))
+        {
+          return -1;
+        }
+      }
+      else if (ud->key == "video" && event == JSONSAX_OBJECT)
+      {
+        if (!ud->self->_video.deserializeSettings(str))
         {
           return -1;
         }

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -390,7 +390,7 @@ void Video::setFramebuffer(void* pixels, unsigned width, unsigned height, unsign
   draw(true);
 }
 
-std::string Video::serialize()
+std::string Video::serializeSettings()
 {
   std::string json("{");
 
@@ -405,7 +405,7 @@ std::string Video::serialize()
   return json;
 }
 
-void Video::deserialize(const char* json)
+bool Video::deserializeSettings(const char* json)
 {
   struct Deserialize
   {
@@ -416,7 +416,8 @@ void Video::deserialize(const char* json)
   Deserialize ud;
   ud.self = this;
 
-  jsonsax_parse(json, &ud, [](void* udata, jsonsax_event_t event, const char* str, size_t num) {
+  jsonsax_result_t res = jsonsax_parse(json, &ud, [](void* udata, jsonsax_event_t event, const char* str, size_t num)
+  {
     auto ud = (Deserialize*)udata;
 
     if (event == JSONSAX_KEY)
@@ -437,6 +438,8 @@ void Video::deserialize(const char* json)
 
     return 0;
   });
+
+  return (res == JSONSAX_OK);
 }
 
 static const char* s_getRotateOptions(int index, void* udata)

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -50,8 +50,8 @@ public:
   const void* getFramebuffer(unsigned* width, unsigned* height, unsigned* pitch, enum retro_pixel_format* format);
   void setFramebuffer(void* pixels, unsigned width, unsigned height, unsigned pitch);
 
-  std::string serialize();
-  void deserialize(const char* json);
+  std::string serializeSettings();
+  bool deserializeSettings(const char* json);
   void showDialog();
 
   unsigned getWindowWidth() const { return _windowWidth; }


### PR DESCRIPTION
closes #266 

The "Video" settings menu is now global. "Keep Aspect Ratio" and "Linear Filtering" will be applied to (and remembered for) all cores. "Rotation" is not remembered, and is reset to "None" whenever a core is loaded.