### PR TITLE
unbind GL_ARRAY_BUFFER to avoid conflicts with the core's rendering

### DIFF
--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -99,7 +99,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)SDL2\include;$(ProjectDir)miniz;$(ProjectDir)RAInterface;$(ProjectDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>LOG_TO_FILE;WIN32;_DEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LOG_TO_FILE;NOMINMAX;WIN32;_DEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -124,7 +124,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>LOG_TO_FILE;WIN32;NDEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LOG_TO_FILE;NOMINMAX;WIN32;NDEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -158,7 +158,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)SDL2\include;$(ProjectDir)miniz;$(ProjectDir)RAInterface;$(ProjectDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <OmitFramePointers>false</OmitFramePointers>
-      <PreprocessorDefinitions>LOG_TO_FILE;_WIN64;_DEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LOG_TO_FILE;NOMINMAX;_WIN64;_DEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -188,7 +188,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)SDL2\include;$(ProjectDir)miniz;$(ProjectDir)RAInterface;$(ProjectDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <OmitFramePointers>false</OmitFramePointers>
-      <PreprocessorDefinitions>LOG_TO_FILE;_WIN64;NDEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LOG_TO_FILE;NOMINMAX;_WIN64;NDEBUG;_WINDOWS;OUTSIDE_SPEEX;RANDOM_PREFIX=speex;_USE_SSE2;FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -171,7 +171,7 @@ bool Video::setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsi
   _hw.enabled = hardwareRender;
   _hw.callback = hwRenderCallback;
 
-  if (!ensureFramebuffer(maxWidth, maxHeight, pixelFormat, _linearFilter))
+  if (!ensureFramebuffer(std::max(width, maxWidth), std::max(height, maxHeight), pixelFormat, _linearFilter))
     return false;
 
   _aspect = aspect;
@@ -646,6 +646,7 @@ bool Video::ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float
   Gl::vertexAttribPointer(uv, 2, GL_FLOAT, GL_FALSE, sizeof(VertexData), (const GLvoid*)offsetof(VertexData, u));
 
   Gl::bindVertexArray(0);
+  Gl::bindBuffer(GL_ARRAY_BUFFER, 0);
   
   _logger->debug(TAG "Vertices updated with window scale %f x %f and texture scale %f x %f", winScaleX, winScaleY, texScaleX, texScaleY);
   return true;


### PR DESCRIPTION
The `VecX` core's hardware rendering mode was not working. A single frame was displayed before the screen turned black, even though the game could be heard running in the background.

In `Video::ensureVertexArray`, a buffer is bound to the VAO upon creation so that it doesn't have to be explicitly bound everytime we draw. It seems, however, that even though the `GL_ARRAY_BUFFER` bind affects the currently bound VAO, it also affects global state. To avoid this conflicting with a core's own rendering, the buffer must be unbound (after the VAO itself is unbound, to keep the association between the two... not weird at all).

There was also a minor issue during the boot of the core, in which it called the set-geometry callback with a max width and height of 0, causing an error: `ensure framebuffer: failed to create hardware render framebuffer 0 x 0`. The core did call set-geometry again soon after with proper values, so the error wasn't noticeable in practice. Still, the geometry's width and height values are now used in place of the corresponding maximums, if the latter are smaller.