### PR TITLE
Add Emulator Settings dialog

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -401,17 +401,27 @@ void Application::runTurbo()
 {
   const auto tTurboStart = std::chrono::steady_clock::now();
 
-  // do four frames without video or audio
+  // disable per-frame rendering in the toolkit
   RA_SuspendRepaint();
+
+  // won't wait for audio buffer to flush - only fill whatever space is available
+  _audio.setBlocking(false);
+
+  // do four frames without video
   for (int i = 0; i < 4; i++)
   {
-    _core.step(false, false);
+    _core.step(false, true);
     RA_DoAchievementsFrame();
   }
 
-  // do a final frame with video and no audio
-  _core.step(true, false);
+  // do a final frame with video
+  _core.step(true, true);
   RA_DoAchievementsFrame();
+
+  // allow normal audio processing
+  _audio.setBlocking(true);
+
+  // restore per-frame rendering in the toolkit
   RA_ResumeRepaint();
 
   // check for periodic SRAM flush

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2183,7 +2183,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       break;
     
     case IDM_TURBO_GAME:
-      _config.setFastForwarding(true);
+      toggleFastForwarding(2);
       break;
 
     case IDM_RESET_GAME:
@@ -2474,7 +2474,7 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
     break;
 
   case KeyBinds::Action::kFastForward:
-    _config.setFastForwarding(static_cast<bool>(extra));
+    toggleFastForwarding(extra);
     break;
 
   case KeyBinds::Action::kReset:
@@ -2491,3 +2491,30 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
   }
 }
 
+void Application::toggleFastForwarding(unsigned extra)
+{
+  // get the current fast forward selection
+  MENUITEMINFO info;
+  memset(&info, 0, sizeof(info));
+  info.cbSize = sizeof(info);
+  info.fMask = MIIM_STATE;
+  GetMenuItemInfo(_menu, IDM_TURBO_GAME, false, &info);
+  const bool checked = (info.fState == MFS_CHECKED);
+
+  switch (extra)
+  {
+    case 0: // FF key released - restore to selection
+      _config.setFastForwarding(checked);
+      break;
+
+    case 1: // FF key pressed - switch to opposite of selection (but don't change selection)
+      _config.setFastForwarding(!checked);
+      break;
+
+    case 2: // FF toggle pressed - switch to opposite of selection (and change selection)
+      _config.setFastForwarding(!checked);
+      info.fState = checked ? MFS_UNCHECKED : MFS_CHECKED;
+      SetMenuItemInfo(_menu, IDM_TURBO_GAME, false, &info);
+      break;
+  }
+}

--- a/src/Application.h
+++ b/src/Application.h
@@ -60,10 +60,6 @@ public:
   bool unloadGame();
   void pauseGame(bool pause);
 
-  bool isTurbo() {
-    return _config.getFastForwarding();
-  }
-
   void printf(const char* fmt, ...);
   Logger& logger() { return _logger; }
 
@@ -121,6 +117,7 @@ protected:
   void        loadConfiguration();
   void        saveConfiguration();
   std::string serializeRecentList();
+  void        toggleFastForwarding(unsigned extra);
 
   Fsm _fsm;
   bool lastHardcore;

--- a/src/Application.h
+++ b/src/Application.h
@@ -60,6 +60,10 @@ public:
   bool unloadGame();
   void pauseGame(bool pause);
 
+  bool isTurbo() {
+    return _config.getFastForwarding();
+  }
+
   void printf(const char* fmt, ...);
   Logger& logger() { return _logger; }
 

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -175,7 +175,6 @@ bool KeyBinds::init(libretro::LoggerComponent* logger)
 
   _logger = logger;
   _slot = 1;
-  _ff = false;
   _gameFocus = false;
 
   if (SDL_NumJoysticks() > 0)
@@ -372,8 +371,8 @@ KeyBinds::Action KeyBinds::translateButtonPress(int button, unsigned* extra)
     // Emulation speed
     case kPauseToggleNoOvl:  return Action::kPauseToggleNoOvl;
     case kPauseToggle:       return Action::kPauseToggle;
-    case kFastForward:       *extra = (unsigned)!_ff; return Action::kFastForward;
-    case kFastForwardToggle: _ff = !_ff; *extra = (unsigned)_ff; return Action::kFastForward;
+    case kFastForward:       *extra = 1; return Action::kFastForward;
+    case kFastForwardToggle: *extra = 2; return Action::kFastForward;
     case kStep:              return Action::kStep;
 
     // Reset
@@ -429,7 +428,7 @@ KeyBinds::Action KeyBinds::translateButtonReleased(int button, unsigned* extra)
     case kJoy1Start:    *extra = JOY_EXTRA(1, 0); return Action::kButtonStart;
 
     // Emulation speed
-    case kFastForward: *extra = (unsigned)_ff; return Action::kFastForward;
+    case kFastForward:  *extra = 0; return Action::kFastForward;
 
     default: return Action::kNothing;
   }

--- a/src/KeyBinds.h
+++ b/src/KeyBinds.h
@@ -76,7 +76,7 @@ public:
     // Emulation speed
     kPauseToggle,
     kPauseToggleNoOvl,
-    kFastForward, // (extra = enabled)
+    kFastForward, // (extra = pressed[0/1],toggle[2])
     kStep,
 
     // Screenshot
@@ -139,7 +139,6 @@ protected:
   std::map<SDL_JoystickID, SDL_JoystickID> _bindingMap;
 
   unsigned _slot;
-  bool _ff;
   bool _gameFocus;
 };
 

--- a/src/States.cpp
+++ b/src/States.cpp
@@ -357,6 +357,17 @@ bool States::loadState(const std::string& path)
     ret = _core->unserialize(data, size);
     if (ret)
       RA_OnLoadState(path.c_str());
+
+    unsigned image_width, image_height, pitch;
+    const void* pixels = util::loadImage(_logger, path + ".png", &image_width, &image_height, &pitch);
+    if (pixels == NULL)
+    {
+      _logger->error(TAG "Error loading savestate screenshot");
+      return true; /* state was still loaded even if the frame buffer wasn't updated */
+    }
+
+    restoreFrameBuffer(pixels, image_width, image_height, pitch);
+    free((void*)pixels);
   }
   else
   {
@@ -380,16 +391,6 @@ bool States::loadState(const std::string& path)
     return false;
   }
 
-  unsigned image_width, image_height, pitch;
-  const void* pixels = util::loadImage(_logger, path + ".png", &image_width, &image_height, &pitch);
-  if (pixels == NULL)
-  {
-    _logger->error(TAG "Error loading savestate screenshot");
-    return true; /* state was still loaded even if the frame buffer wasn't updated */
-  }
-
-  restoreFrameBuffer(pixels, image_width, image_height, pitch);
-  free((void*)pixels);
   return true;
 }
 

--- a/src/components/Audio.h
+++ b/src/components/Audio.h
@@ -58,12 +58,15 @@ public:
   virtual bool setRate(double rate) override;
   virtual void mix(const int16_t* samples, size_t frames) override;
 
+  void setBlocking(bool value) { _blocking = value; }
+
 protected:
   libretro::LoggerComponent* _logger;
 
   double _sampleRate;
   double _coreRate;
   int _channels;
+  bool _blocking;
 
   double _currentRatio;
   double _originalRatio;

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -49,6 +49,9 @@ public:
   virtual bool getFastForwarding() override { return _fastForwarding; }
   virtual void setFastForwarding(bool value) override { _fastForwarding = value; }
 
+  virtual bool getAudioWhileFastForwarding() override { return _audioWhileFastForwarding; }
+  virtual int getFastForwardRatio() override { return _fastForwardRatio; }
+
   void setSaveDirectory(const std::string& path) { _saveFolder = path; }
 
   const char* getRootFolder()
@@ -66,8 +69,12 @@ public:
 
   bool validateSettingsForHardcore(const char* library_name, bool prompt);
 
+  std::string serializeEmulatorSettings();
+  bool deserializeEmulatorSettings(const char* json);
+
 #ifdef _WINDOWS
   void showDialog(const std::string& coreName, Input& input);
+  void showEmulatorSettingsDialog();
 #endif
 
 protected:
@@ -100,6 +107,9 @@ protected:
   bool _updated;
   bool _fastForwarding;
   bool _hadDisallowedSetting;
+  bool _audioWhileFastForwarding;
+
+  int _fastForwardRatio;
 
   std::string _key;
 };

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -148,6 +148,9 @@ namespace libretro
 
     virtual bool getFastForwarding() = 0;
     virtual void setFastForwarding(bool value) = 0;
+
+    virtual bool getAudioWhileFastForwarding() = 0;
+    virtual int getFastForwardRatio() = 0;
   };
 
   /**

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -115,6 +115,16 @@ namespace
     {
       (void)value;
     }
+
+    virtual bool getAudioWhileFastForwarding() override
+    {
+      return false;
+    }
+
+    virtual int getFastForwardRatio() override
+    {
+      return 5;
+    }
   };
 
   class DummyVideoContext : public libretro::VideoContextComponent

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -107,6 +107,7 @@ main MENU
             MENUITEM "Controller 1...", IDM_INPUT_CONTROLLER_1
             MENUITEM "Controller 2...", IDM_INPUT_CONTROLLER_2
         }
+        MENUITEM "Emulator...", IDM_EMULATOR_CONFIG
         MENUITEM "Saving...", IDM_SAVING_CONFIG
         MENUITEM "Video...", IDM_VIDEO_CONFIG
         POPUP "Window Size"

--- a/src/resource.h
+++ b/src/resource.h
@@ -89,3 +89,4 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 #define IDM_INPUT_CONTROLLER_2                  40015
 #define IDM_MANAGE_CORES                        40016
 #define IDM_SAVING_CONFIG                       40017
+#define IDM_EMULATOR_CONFIG                     40018


### PR DESCRIPTION
Adds options for fast forward rate (2x-10x) and playing audio while fast forwarding (closes #243).

![image](https://user-images.githubusercontent.com/32680403/116574426-ee4fcf00-a8ca-11eb-87b1-af7b1d96f73d.png)

Note: Fast forward rate just indicates how often to render a frame. It doesn't guarantee the specified speed up. For example, at 10x, only one frame is rendered out of every 10. Depending on the complexity of the core and the power of your computer, it may take as long as rendering four or five frames at normal speed, resulting in the appearance of double speed instead of 10x.