### PR TITLE
Add m3u to picodrive and mark supported for Sega CD

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -502,9 +502,8 @@
   },
   "picodrive_libretro":{
     "name": "PicoDrive",
-    "extensions": "cue",
-    "systems": [9],
-    "platforms": "none"
+    "extensions": "cue|m3u",
+    "systems": [9]
   },
   "picodrive_libretro":{
     "name": "PicoDrive",


### PR DESCRIPTION
From some quick tests everything looks identical to GPGX. I see no specific reason for the core to be unsupported at this point. The m3u support is brand new, via libretro/picodrive#154. Of note, this core will be required to develop any 32X CD games.