### PR TITLE
allow sram size mismatch

### DIFF
--- a/src/States.cpp
+++ b/src/States.cpp
@@ -495,16 +495,22 @@ void States::loadSRAM(libretro::Core* core)
     void* data = util::loadFile(_logger, sramPath, &fileSize);
     if (data != NULL)
     {
+      void* memory = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
       if (fileSize == sramSize)
       {
-        void* memory = core->getMemoryData(RETRO_MEMORY_SAVE_RAM);
-        memcpy(memory, data, sramSize);
         _logger->info(TAG "Loaded %lu bytes of Save RAM from disk", fileSize);
+      }
+      else if (fileSize <= sramSize)
+      {
+        _logger->warn(TAG "Loaded %lu bytes of Save RAM from disk, wanted %lu", fileSize, sramSize);
       }
       else
       {
-        _logger->error(TAG "Save RAM size mismatch, wanted %lu, got %lu from disk", sramSize, fileSize);
+        _logger->warn(TAG "Loaded %lu bytes of Save RAM from disk, truncated from %lu", sramSize, fileSize);
+        fileSize = sramSize;
       }
+
+      memcpy(memory, data, fileSize);
 
       if (_saveInterval > 0)
         _lastSaveData = data;


### PR DESCRIPTION
Fixes issue reading SRAM for Sonic Delta 40MB. The amount of SRAM requested by the core when starting the game greatly exceeds the amount provided when exiting the game. The code treated this as an error and ignored the SRAM when reloading the game.

RetroArch does not treat this as an error and only loads the amount available. I have made similar changes here.