### PR TITLE
let windows manage default file extension; add all files to open state dialog

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1555,16 +1555,16 @@ void Application::loadGame()
   }
 
   file_types.reserve(supported_exts.size() * 2 + 32);
-  file_types.append("All Files (*.*)");
-  file_types.append("\0", 1);
-  file_types.append("*.*");
-  file_types.append("\0", 1);
   file_types.append("Supported Files (");
   file_types.append(supported_exts);
   file_types.append(")");
   file_types.append("\0", 1);
   file_types.append(supported_exts);
   file_types.append("\0", 1);
+  file_types.append("All Files (*.*)");
+  file_types.append("\0", 1);
+  file_types.append("*.*");
+  file_types.append("\0", 2);
 
   std::string path = util::openFileDialog(g_mainWindow, file_types);
 
@@ -1785,15 +1785,10 @@ void Application::saveState()
   extensions.append("\0", 1);
   extensions.append("*.state");
   extensions.append("\0", 2);
-  std::string path = util::saveFileDialog(g_mainWindow, extensions);
+  std::string path = util::saveFileDialog(g_mainWindow, extensions, "state");
 
   if (!path.empty())
   {
-    if (util::extension(path).empty())
-    {
-      path += ".state";
-    }
-
     saveState(path);
   }
 }
@@ -1824,15 +1819,17 @@ void Application::loadState()
   std::string extensions = "State Files (*.state)";
   extensions.append("\0", 1);
   extensions.append("*.state");
+  extensions.append("\0", 1);
+  extensions.append("All Files (*.*)");
+  extensions.append("\0", 1);
+  extensions.append("*.*");
   extensions.append("\0", 2);
   std::string path = util::openFileDialog(g_mainWindow, extensions);
 
-  if (path.empty())
+  if (!path.empty())
   {
-    return;
+    loadState(path);
   }
-
-  loadState(path);
 }
 
 void Application::screenshot()

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -673,7 +673,7 @@ std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)
   cfg.lStructSize = sizeof(cfg);
   cfg.hwndOwner = hWnd;
   cfg.lpstrFilter = unicodeExtensionsFilter.c_str();
-  cfg.nFilterIndex = 2;
+  cfg.nFilterIndex = 1;
   cfg.lpstrFile = path;
   cfg.nMaxFile = sizeof(path)/sizeof(path[0]);
   cfg.lpstrTitle = L"Load";
@@ -689,9 +689,10 @@ std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)
   }
 }
 
-std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter)
+std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension)
 {
   std::wstring unicodeExtensionsFilter = util::utf8ToUChar(extensionsFilter);
+  std::wstring unicodeDefaultExtension;
   wchar_t path[_MAX_PATH];
   path[0] = 0;
 
@@ -701,11 +702,17 @@ std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter)
   cfg.lStructSize = sizeof(cfg);
   cfg.hwndOwner = hWnd;
   cfg.lpstrFilter = unicodeExtensionsFilter.c_str();
-  cfg.nFilterIndex = 2;
+  cfg.nFilterIndex = 1;
   cfg.lpstrFile = path;
   cfg.nMaxFile = sizeof(path)/sizeof(path[0]);
   cfg.lpstrTitle = L"Save";
   cfg.Flags = OFN_NOREADONLYRETURN | OFN_OVERWRITEPROMPT;
+
+  if (defaultExtension)
+  {
+    unicodeDefaultExtension = util::utf8ToUChar(defaultExtension);
+    cfg.lpstrDefExt = unicodeDefaultExtension.c_str();
+  }
 
   if (GetSaveFileNameW(&cfg) == TRUE)
   {

--- a/src/Util.h
+++ b/src/Util.h
@@ -77,7 +77,7 @@ namespace util
 
 #ifdef _WINDOWS
   std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter);
-  std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter);
+  std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension = NULL);
 #endif
 
   const void* toPng(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format, int* len);


### PR DESCRIPTION
fixes an issue where using the manual save state feature would not correctly append the extension if the filename (or path) contained a period.