### PR TITLE
use smaller buffer for audio resampling

### DIFF
--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -199,6 +199,7 @@ namespace libretro
     
     int16_t*                        _samples;
     size_t                          _samplesCount;
+    bool                            _generateAudio;
 
     const char*                     _libretroPath;
     unsigned                        _performanceLevel;


### PR DESCRIPTION
RetroArch immediately passes any audio provided by the core to the audio device. RALibretro buffers several chunks of audio before passing the data to the core to minimize crackling due to resampling such small samples.

libretro cores are throttled entirely by how quickly the audio data is processed. If the audio device buffer is full, the code _will wait_ in the audio providing code until the audio device has processed some of the buffered data and there's space to queue the new data.

RALibretro uses a large enough buffer that an entire frame's worth of audio can be captured before it's flushed to the audio device. Despite pushing the same amount of data to the audio device, doing so outside of the `core.step` function appears to affect the timing of some cores (notably PPSSPP and flycast). I don't claim to understand why, but I suspect it has something to do with multi-threading.

To address this, and still minimize crackling due to resampling, I've selected a smaller buffer. As that buffer gets filled within the frame, it will push the data to the audio device. This allows many very small samples (as provided by cores like snes9x) to be resampled together, but ensures the resampler still gets called within `core.step`.
