### PR TITLE
add timestamps to log

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -55,6 +55,8 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 //#define DISPLAY_FRAMERATE 1
 //#define DEBUG_FRAMERATE 1
 
+//#define DEBUG_AUDIO 1
+
 HWND g_mainWindow;
 Application app;
 
@@ -110,6 +112,13 @@ bool Application::init(const char* title, int width, int height)
   _logger.info(TAG "RALibretro version %s starting", git::getReleaseVersion());
 #endif
   _logger.info(TAG "RALibretro commit hash is %s", git::getFullHash());
+
+  const time_t now_timet = time(0);
+  std::tm now_tm;
+  localtime_s(&now_tm, &now_timet);
+  char buffer[64];
+  strftime(buffer, sizeof(buffer), "%D %T %Z", &now_tm);
+  _logger.info(TAG "Current time is %s", buffer);
 
   if (!_config.init(&_logger))
   {
@@ -1540,12 +1549,16 @@ void Application::s_audioCallback(void* udata, Uint8* stream, int len)
     else
     {
       app->_fifo.read((void*)stream, len);
+#ifdef DEBUG_AUDIO
       app->_logger.debug("[AUD] Audio hardware requested %d bytes", len);
+#endif
     }
   }
   else
   {
+#ifdef DEBUG_AUDIO
     app->_logger.debug("[AUD] Audio hardware requested %d bytes, game is not running, sending silence", len);
+#endif
     memset((void*)stream, 0, len);
   }
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -117,7 +117,7 @@ bool Application::init(const char* title, int width, int height)
   std::tm now_tm;
   localtime_s(&now_tm, &now_timet);
   char buffer[64];
-  strftime(buffer, sizeof(buffer), "%D %T %Z", &now_tm);
+  strftime(buffer, sizeof(buffer), "%m/%d/%y %H:%M:%S %Z", &now_tm);
   _logger.info(TAG "Current time is %s", buffer);
 
   if (!_config.init(&_logger))

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -113,12 +113,14 @@ bool Application::init(const char* title, int width, int height)
 #endif
   _logger.info(TAG "RALibretro commit hash is %s", git::getFullHash());
 
-  const time_t now_timet = time(0);
-  std::tm now_tm;
-  localtime_s(&now_tm, &now_timet);
-  char buffer[64];
-  strftime(buffer, sizeof(buffer), "%m/%d/%y %H:%M:%S %Z", &now_tm);
-  _logger.info(TAG "Current time is %s", buffer);
+  {
+    const time_t now_timet = time(0);
+    std::tm now_tm;
+    localtime_s(&now_tm, &now_timet);
+    char buffer[64];
+    strftime(buffer, sizeof(buffer), "%m/%d/%y %H:%M:%S %Z", &now_tm);
+    _logger.info(TAG "Current time is %s", buffer);
+  }
 
   if (!_config.init(&_logger))
   {
@@ -1738,7 +1740,7 @@ void Application::updateDiscMenu(bool updateLabels)
 
       if (updateLabels)
       {
-        if ((int)i < _discPaths.size())
+        if (i < _discPaths.size())
         {
           const std::string& path = _discPaths.at(i);
           size_t index = path.find_last_of('\\');

--- a/src/components/Logger.cpp
+++ b/src/components/Logger.cpp
@@ -21,6 +21,7 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef LOG_TO_FILE
 #include "Util.h"
+#include <chrono>
 #endif
 
 #include <memory.h>
@@ -119,8 +120,17 @@ void Logger::log(enum retro_log_level level, const char* line, size_t length)
 #ifdef LOG_TO_FILE
   if (_file)
   {
+    const std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+    const unsigned int now_ms = (unsigned int)
+      (std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count() % 1000);
+    const time_t now_timet = std::chrono::system_clock::to_time_t(now);
+    std::tm now_tm;
+    localtime_s(&now_tm, &now_timet);
+    char buffer[10];
+    strftime(buffer, sizeof(buffer), "%H%M%S", &now_tm);
+
     // Log to the log file.
-    fprintf(_file, "[%s] %s\n", desc, line);
+    fprintf(_file, "%s.%03u [%s] %s\n", buffer, now_ms, desc, line);
 #ifndef NDEBUG
     fflush(_file);
 #endif


### PR DESCRIPTION
Adds an `HHMMSS.xxx` prefix to each line of the log as it's written to the file. These timestamps are not included in the about dialog's running log.

```
181632.438 [INFO ] [APP] RALibretro version 1.3.7.4-x64 starting
181632.439 [INFO ] [APP] RALibretro commit hash is 516f7754d9865ee0d9d077ade60ab2c894c445c6
181632.439 [INFO ] [APP] Current time is 08/29/21 18:16:32 Mountain Daylight Time
181632.441 [INFO ] [CFG] Root folder:        E:\Source\RetroAchievements\RALibretro\bin64\
181632.441 [INFO ] [CFG] Assets folder:      E:\Source\RetroAchievements\RALibretro\bin64\Assets\
181632.441 [INFO ] [CFG] Save folder:        E:\Source\RetroAchievements\RALibretro\bin64\Saves\
181632.441 [INFO ] [CFG] System folder:      E:\Source\RetroAchievements\RALibretro\bin64\System\
181632.441 [INFO ] [CFG] Screenshots folder: E:\Source\RetroAchievements\RALibretro\bin64\Screenshots\
181633.782 [INFO ] [OGL] Initializing OpenGL 4.6.13596 Compatibility Profile Context 20.10.35.02 27.20.1034.6
181633.943 [INFO ] [APP] Initialized audio device. 2 channels@44100Hz (format:8010, silence:0, samples:1024, padding:0, size:4096)
181633.944 [DEBUG] [INP] Loaded 315 controller mappings
181633.945 [INFO ] [INP] Controller Keyboard (Keyboard) added
181634.505 [DEBUG] [EMU] Identifying available cores
181634.505 [INFO ] [UTL] Read 15787 bytes from "E:\Source\RetroAchievements\RALibretro\bin64\Cores\cores.json"
181634.552 [DEBUG] [APP] Recent file list cleared
181634.552 [INFO ] [UTL] Read 3181 bytes from "E:\Source\RetroAchievements\RALibretro\bin64\RALibretro.json"
```