### PR TITLE
add support for RETRO_ENVIRONMENT_GET_VFS_INTERFACE

### DIFF
--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -137,6 +137,7 @@ namespace libretro
     bool setInputDescriptors(const struct retro_input_descriptor* data);
     bool setDiskControlInterface(const struct retro_disk_control_callback* data);
     bool setDiskControlExtInterface(const struct retro_disk_control_ext_callback* data);
+    bool getVfsInterface(struct retro_vfs_interface_info* data);
     bool setHWRender(struct retro_hw_render_callback* data);
     bool getVariable(struct retro_variable* data);
     bool setVariables(const struct retro_variable* data);


### PR DESCRIPTION
Prevents crash when loading melonDS core (core still crashes when unloading the game). 

Also leveraged by the Beetle SuperGrafx core (though it will fallback to an internal implementation if not provided by the frontend).