### PR TITLE
add support for RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2

### DIFF
--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -42,6 +42,8 @@ public:
 
   virtual void setVariables(const struct retro_variable* variables, unsigned count) override;
   virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) override;
+  virtual void setVariables(const struct retro_core_option_v2_definition* options, unsigned count,
+    const struct retro_core_option_v2_category* categories, unsigned category_count) override;
   virtual void setVariableDisplay(const struct retro_core_option_display* display) override;
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
@@ -80,6 +82,14 @@ public:
 protected:
   static const char* s_getOption(int index, void* udata);
 
+  struct Category
+  {
+    std::string _key;
+    std::string _name;
+    std::string _description;
+    int         _visibleCount;
+  };
+
   struct Variable
   {
     std::string _key;
@@ -87,11 +97,36 @@ protected:
     int         _selected;
     bool        _hidden;
 
+    Category*   _category;
+
     std::vector<std::string> _options;
     std::vector<std::string> _labels;
   };
 
+  class ConfigDialog : public Dialog
+  {
+  public:
+    std::vector<Variable*> variables;
+    std::vector<int> selections;
+    std::vector<std::string> categoryNames;
+    Config* owner;
+    int maxCount;
+    Category* category;
+    bool updated;
+
+    void updateVariables();
+
+  protected:
+    void initControls(HWND hwnd) override;
+
+    INT_PTR dialogProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) override;
+    void retrieveData(HWND hwnd) override;
+
+    HWND hwnd;
+  };
+
   static void initializeControllerVariable(Variable& variable, const char* name, const char* key, const std::map<std::string, unsigned>& names, unsigned selectedDevice);
+  void setOptions(Variable& var, const retro_core_option_value* values, const char* default_value);
 
   libretro::LoggerComponent* _logger;
 
@@ -101,6 +136,7 @@ protected:
   std::string _systemFolder;
   std::string _screenshotsFolder;
 
+  std::vector<Category> _categories;
   std::vector<Variable> _variables;
   std::unordered_map<std::string, std::string> _selections;
 

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -142,6 +142,8 @@ namespace libretro
 
     virtual void setVariables(const struct retro_variable* variables, unsigned count) = 0;
     virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) = 0;
+    virtual void setVariables(const struct retro_core_option_v2_definition* options, unsigned count,
+      const struct retro_core_option_v2_category* categories, unsigned category_count) = 0;
     virtual void setVariableDisplay(const struct retro_core_option_display* display) = 0;
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -93,6 +93,15 @@ namespace
       (void)count;
     }
 
+    virtual void setVariables(const struct retro_core_option_v2_definition* options, unsigned count,
+      const struct retro_core_option_v2_category* categories, unsigned category_count) override
+    {
+      (void)options;
+      (void)count;
+      (void)categories;
+      (void)category_count;
+    }
+
     virtual void setVariableDisplay(const struct retro_core_option_display* display) override
     {
       (void)display;
@@ -1294,7 +1303,7 @@ bool libretro::Core::getInputBitmasks(bool* data)
 
 bool libretro::Core::getCoreOptionsVersion(unsigned* data) const
 {
-  *data = 1;
+  *data = 2;
   return true;
 }
 
@@ -1316,6 +1325,32 @@ bool libretro::Core::setCoreOptions(const struct retro_core_option_definition* d
 bool libretro::Core::setCoreOptionsIntl(const struct retro_core_options_intl* data)
 {
   return setCoreOptions(data->us);
+}
+
+bool libretro::Core::setCoreOptionsV2(const struct retro_core_options_v2* data)
+{
+  const struct retro_core_option_v2_definition* option;
+  const struct retro_core_option_v2_category* category;
+  unsigned count, category_count;
+
+  for (category = data->categories; category->key != NULL; category++)
+    ;
+  category_count = category - data->categories;
+
+  _logger->debug(TAG "retro_options_v2");
+  for (option = data->definitions; option->key != NULL; option++)
+    _logger->debug(TAG "  %s: %s", option->key, option->desc);
+
+  count = option - data->definitions;
+
+  _config->setVariables(data->definitions, count, data->categories, category_count);
+
+  return true;
+}
+
+bool libretro::Core::setCoreOptionsV2Intl(const struct retro_core_options_v2_intl* data)
+{
+  return setCoreOptionsV2(data->us);
 }
 
 bool libretro::Core::setCoreOptionsDisplay(const struct retro_core_option_display* data)
@@ -1569,6 +1604,19 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
   case RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE:
     ret = setContentInfoOverride((const struct retro_system_content_info_override*)data);
     break;
+
+  case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+    ret = setCoreOptionsV2((const struct retro_core_options_v2*)data);
+    break;
+
+  case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL:
+    ret = setCoreOptionsV2Intl((const struct retro_core_options_v2_intl*)data);
+    break;
+
+  /* RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK cannot be supported because
+   * we don't update the variable values in real time. values are only updated when the config
+   * dialog is closed.
+   */
 
   default:
     /* we don't care about private events */

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -162,6 +162,8 @@ namespace libretro
     bool getCoreOptionsVersion(unsigned* data) const;
     bool setCoreOptions(const struct retro_core_option_definition* data);
     bool setCoreOptionsIntl(const struct retro_core_options_intl* data);
+    bool setCoreOptionsV2(const struct retro_core_options_v2* data);
+    bool setCoreOptionsV2Intl(const struct retro_core_options_v2_intl* data);
     bool setCoreOptionsDisplay(const struct retro_core_option_display* data);
     bool getPreferredHWRender(unsigned* data);
 


### PR DESCRIPTION
Supports categories for core settings (when implemented by the core).

Before:
![image](https://user-images.githubusercontent.com/32680403/132618720-e3cdf95e-76a3-499d-9910-53e06c7fffd2.png)

After:
![image](https://user-images.githubusercontent.com/32680403/132618731-d27b71b6-770d-4582-bc7f-b8cd8a853403.png)
![image](https://user-images.githubusercontent.com/32680403/132618740-343ee763-2378-43bb-b999-fd70e9a49cc2.png)
