### PR TITLE
allow non-game CDs to be loaded without unloading game

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1305,7 +1305,7 @@ bool Application::loadGame(const std::string& path)
 
   _gameFileName = unzippedFileName; // store for GetEstimatedTitle callback
 
-  if (!romLoaded(&_logger, _system, path, data, size))
+  if (!romLoaded(&_logger, _system, path, data, size, false))
   {
     _discPaths.clear();
     updateDiscMenu(true);
@@ -2341,14 +2341,14 @@ void Application::handle(const SDL_SysWMEvent* syswm)
         unsigned newDiscIndex = cmd - IDM_CD_DISC_FIRST;
         if (_core.getCurrentDiscIndex() != newDiscIndex)
         {
-          _core.setCurrentDiscIndex(newDiscIndex);
-
           if (newDiscIndex < _discPaths.size())
           {
             std::string path = util::replaceFileName(_gamePath, _discPaths.at(newDiscIndex).c_str());
-            romLoaded(&_logger, _system, path, NULL, 0);
+            if (!romLoaded(&_logger, _system, path, NULL, 0, true))
+              break;
           }
 
+          _core.setCurrentDiscIndex(newDiscIndex);
           updateDiscMenu(false);
         }
       }

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -33,5 +33,5 @@ void RA_OnLoadNewRom(BYTE* pROMData, unsigned int nROMSize);
 
 #include "Emulator.h"
 
-bool   romLoaded(Logger* logger, int consoleId, const std::string& path, void* rom, size_t size);
+bool   romLoaded(Logger* logger, int consoleId, const std::string& path, void* rom, size_t size, bool changingDiscs);
 void   romUnloaded(Logger* logger);

--- a/src/RA_Implementation.cpp
+++ b/src/RA_Implementation.cpp
@@ -7,7 +7,6 @@
 #include "Git.h"
 
 extern HWND g_mainWindow;
-int g_activeGame;
 
 bool isGameActive();
 void getGameName(char name[], size_t len);
@@ -114,18 +113,4 @@ void RA_Init(HWND hWnd)
 
   // ensure titlebar text matches expected format
   RA_UpdateAppTitle("");
-}
-
-void RA_ActivateDisc(int loadedGame)
-{
-  if (loadedGame != g_activeGame)
-  {
-    g_activeGame = loadedGame;
-    RA_ActivateGame(loadedGame);
-  }
-}
-
-void RA_DeactivateDisc()
-{
-  g_activeGame = 0;
 }


### PR DESCRIPTION
Simplifies the process of loading discs not associated with the game for games like Vib-Ribbon and Monster Rancher.

Makes three changes:
* Selecting an audio CD from an .m3u will not unload the achievement set. Previously the achievement set was unloaded.
* Selecting a disc associated to a known game will not unload the achievement set. Previously the achievement set was replaced with the achievements for the alternate game.
* Selecting a disc not associated to a known game will not unload the achievement set. However, as an unknown disc may just be a modified version of the base game, so doing so is not allowed in hardcore. Previously the achievement set was unloaded.