### PR TITLE
log when core tries to call a RetroArch-specific callback

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -161,7 +161,7 @@
     "name": "Flycast",
     "extensions": "gdi|m3u",
     "systems": [40],
-    "platforms": "none"
+    "platforms": "win64"
   },
   "fmsx_libretro":{
     "name": "fMSX",

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1019,6 +1019,11 @@ bool Application::loadCore(const std::string& coreName)
       // see https://github.com/hrydgard/ppsspp/issues/14748
       _config.deserialize("{\"ppsspp_frame_duplication\":\"enabled\"}");
     }
+    else if (coreName == "flycast_libretro")
+    {
+      // flycast crashes on save/load state when using threaded rendering
+      _config.deserialize("{\"reicast_threaded_rendering\":\"disabled\"}");
+    }
     else if (coreName == "fbneo_libretro")
     {
       // this setting must be off for hardcore mode, but defaults to enabled

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -42,6 +42,12 @@ SOFTWARE.
 
 #define TAG "[COR] "
 
+/* These are RetroArch specific callbacks. Some cores expect at least minimal support for them */
+#define RETRO_ENVIRONMENT_RETROARCH_START_BLOCK 0x800000
+#define RETRO_ENVIRONMENT_SET_SAVE_STATE_IN_BACKGROUND (2 | RETRO_ENVIRONMENT_RETROARCH_START_BLOCK)
+#define RETRO_ENVIRONMENT_GET_CLEAR_ALL_THREAD_WAITS_CB (3 | RETRO_ENVIRONMENT_RETROARCH_START_BLOCK)
+#define RETRO_ENVIRONMENT_POLL_TYPE_OVERRIDE (4 | RETRO_ENVIRONMENT_RETROARCH_START_BLOCK)
+
 /* Some libretro callbacks need access to the other frontend elements that are stored
  * in the core instance (like _input). Since we can't pass pointers through libretro,
  * keep a global pointer to the current core object (there should be only one).
@@ -1567,6 +1573,11 @@ bool libretro::Core::setCoreOptionsDisplay(const struct retro_core_option_displa
   return true;
 }
 
+static bool clearAllWaitThreadsCallback(unsigned clear_threads, void* data)
+{
+  return true;
+}
+
 static void getEnvName(char* name, size_t size, unsigned cmd)
 {
   static const char* names[] =
@@ -1829,6 +1840,21 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
    * we don't update the variable values in real time. values are only updated when the config
    * dialog is closed.
    */
+
+  case RETRO_ENVIRONMENT_SET_SAVE_STATE_IN_BACKGROUND:
+    _logger->warn(TAG "Unimplemented env call: %s", "RETRO_ENVIRONMENT_SET_SAVE_STATE_IN_BACKGROUND");
+    return false;
+
+  case RETRO_ENVIRONMENT_GET_CLEAR_ALL_THREAD_WAITS_CB:
+    /* flycast crashes on exit unless this provides a valid callback. This is just a
+     * dummy function, so we're still going to log it like it's unimplemented. */
+    _logger->warn(TAG "Unimplemented env call: %s", "RETRO_ENVIRONMENT_GET_CLEAR_ALL_THREAD_WAITS_CB");
+    *(retro_environment_t*)data = clearAllWaitThreadsCallback;
+    return false;
+
+  case RETRO_ENVIRONMENT_POLL_TYPE_OVERRIDE:
+    _logger->warn(TAG "Unimplemented env call: %s", "RETRO_ENVIRONMENT_POLL_TYPE_OVERRIDE");
+    return false;
 
   default:
     /* we don't care about private events */


### PR DESCRIPTION
RetroArch provides a few environment callbacks that are specific for RetroArch. 
https://github.com/libretro/RetroArch/blob/2b87cd931372f775c64f25ed2b04eea72da87df7/retroarch.h#L46-L73

This adds logging messages to report these as unsupported callbacks.