### PR TITLE
deprecate duckstation

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -135,6 +135,7 @@
   "duckstation_libretro":{
     "name": "DuckStation",
     "extensions": "m3u|cue",
+    "deprecated": "DuckStation is no longer maintained. Please use SwanStation.",
     "systems": [12]
   },
   "fbalpha_libretro":{
@@ -614,8 +615,7 @@
   "swanstation_libretro":{
     "name": "SwanStation",
     "extensions": "m3u|cue",
-    "systems": [12],
-    "platforms": "none"
+    "systems": [12]
   },
   "tgbdual_libretro":{
     "name": "TGB Dual",


### PR DESCRIPTION
SwanStation is the libretro fork of DuckStation. The DuckStation build is no longer being maintained.