### PR TITLE
eliminate attempt to match core-specified framerate

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -87,6 +87,7 @@ protected:
   void        processEvents();
   void        runSmoothed();
   void        runTurbo();
+  void        pauseForBadPerformance();
 
   void        loadGame();
   void        enableItems(const UINT* items, size_t count, UINT enable);
@@ -139,6 +140,12 @@ protected:
   Input        _input;
   Memory       _memory;
   States       _states;
+
+  int          _numAudioFaults;
+  int          _numAudioRecoveries;
+  int          _audioGeneratedDuringFastForward;
+  bool         _vsyncDisabledByAudioFaults;
+  bool         _processingEvents;
 
   KeyBinds _keybinds;
   std::vector<RecentItem> _recentList;

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -64,6 +64,7 @@ namespace libretro
     inline bool                    getSupportAchievements() const { return _supportAchievements; }
     inline void                    unloadGame()                   { _core.unloadGame(); }
     inline bool                    gameLoaded()             const { return _gameLoaded; }
+    void                           resetVsync();
 
     inline unsigned                getNumDiscs()            const { return (_diskControlInterface.get_num_images != NULL) ? _diskControlInterface.get_num_images() : 0; }
     inline unsigned                getCurrentDiscIndex()    const { return (_diskControlInterface.get_image_index != NULL) ? _diskControlInterface.get_image_index() : 0; }
@@ -155,6 +156,7 @@ namespace libretro
     bool getSaveDirectory(const char** data) const;
     bool setContentInfoOverride(const struct retro_system_content_info_override* data);
     bool setSystemAVInfo(const struct retro_system_av_info* data);
+    bool handleSystemAVInfoChanged();
     bool setSubsystemInfo(const struct retro_subsystem_info* data);
     bool setControllerInfo(const struct retro_controller_info* data);
     bool setMemoryMaps(const struct retro_memory_map* data);


### PR DESCRIPTION
Both PPSSPP and Flycast sometimes only generate 30 frames of video per second, even though the core says it's supposed to be generating 60 fps. This causes RALibretro to drop frames trying to bring the framerate back up to the specified level (see #104).

PPSSPP has a workaround for this: "duplicate frames in 30hz", but Flycast does not.

RetroArch seems to derive its actual framerate purely from the speed at which the audio is generated (see also #300). Instead of relying on the fps calculation to determine if frames need to be dropped, this implementation relies on the ability of the core to generate audio quicker than it can be consumed. Similar to #104, if the audio is not being generated fast enough, vsync will be disabled. If it still is not being generated fast enough, the user will be informed that they should examine their settings. No attempt is made to drop frames to automatically correct the performance issue as the audio polling routine is separate from the emulation loop, which makes the calculations for determining how many frames to drop much more difficult. A player who cannot get RALibretro to perform at an acceptable level can use RetroArch instead.