### PR TITLE
don't refresh memory map unless game loaded

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2112,7 +2112,8 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       
     case IDM_CORE_CONFIG:
       _config.showDialog(_core.getSystemInfo()->library_name, _input);
-      refreshMemoryMap();
+      if (isGameActive())
+        refreshMemoryMap();
       break;
 
     case IDM_INPUT_CONFIG:


### PR DESCRIPTION
prevents a crash using the core settings dialog if the core hasn't initialized its memory regions
