### PR TITLE
deliver built artifacts in releases page

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -56,14 +56,6 @@ jobs:
         uses: egor-tensin/setup-mingw@v2
       - name: Build
         run: make ARCH=x86
-      - name: Zip
-        if: startsWith(github.ref, 'refs/tags/')
-        run: make ARCH=x86 zip
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: RALibretro-x86*.zip
 
   RALibretro-Win64-cross-compile:
     runs-on: ubuntu-latest
@@ -80,14 +72,6 @@ jobs:
         uses: egor-tensin/setup-mingw@v2
       - name: Build
         run: make ARCH=x64
-      - name: Zip
-        if: startsWith(github.ref, 'refs/tags/')
-        run: make ARCH=x64 zip
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: RALibretro-x64*.zip
 
   RAHasher-x86:
     runs-on: ubuntu-latest

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -102,11 +102,14 @@ jobs:
           sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
       - name: Build
         run: make ARCH=x86 -f Makefile.RAHasher
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x86 -f Makefile.RAHasher zip
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: bin/RAHasher*
+          files: RAHasher*.zip
 
   RAHasher-x64:
     runs-on: ubuntu-latest
@@ -121,8 +124,11 @@ jobs:
           sudo apt-get install gcc-multilib # bits/libc-header-start.h
       - name: Build
         run: make ARCH=x64 -f Makefile.RAHasher
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x64 -f Makefile.RAHasher zip
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: bin64/RAHasher*
+          files: RAHasher*.zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,95 +2,127 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master,develop ]
+    branches:
+      - master
+      - develop
+    tags:
+      - "*"
   pull_request:
-    branches: [ master,develop ]
+    branches:
+      - master
+      - develop
 
 jobs:
   RALibretro-Win32:
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
-    - name: Build
-      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install Windows SDK 8.1
+        run: choco install windows-sdk-8.1
+      - name: Build
+        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
 
   RALibretro-Win64:
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
-    - name: Build
-      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install Windows SDK 8.1
+        run: choco install windows-sdk-8.1
+      - name: Build
+        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
 
   RALibretro-Win32-cross-compile:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Install MinGW
-      uses: egor-tensin/setup-mingw@v2
-    - name: Build
-      run: make ARCH=x86
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Install MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Build
+        run: make ARCH=x86
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x86 zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: RALibretro-x86*.zip
 
   RALibretro-Win64-cross-compile:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Install MinGW
-      uses: egor-tensin/setup-mingw@v2
-    - name: Build
-      run: make ARCH=x64
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Install MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Build
+        run: make ARCH=x64
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x64 zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: RALibretro-x64*.zip
 
   RAHasher-x86:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
-    - name: Build
-      run: make ARCH=x86 -f Makefile.RAHasher
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
+      - name: Build
+        run: make ARCH=x86 -f Makefile.RAHasher
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: bin/RAHasher*
 
   RAHasher-x64:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Build
-      run: make ARCH=x64 -f Makefile.RAHasher
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Build
+        run: make ARCH=x64 -f Makefile.RAHasher
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: bin64/RAHasher*

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 *.swp
 *.log
 *.pdb
+*.zip
 .vs
 /bin
 /bin64
-/RALibretro*.zip
 /obj
 /src/Git.cpp

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ src/Git.cpp: etc/Git.cpp.template FORCE
 
 zip:
 	rm -f $(OUTDIR)/RALibretro-*.zip RALibretro-*.zip
-	zip -9 RALibretro-$(ARCH)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RALibretro.exe
+	zip -9 RALibretro-`git describe | tr -d "\n"`.zip $(OUTDIR)/RALibretro.exe
 
 clean:
 	rm -f $(OUTDIR)/RALibretro.exe $(OBJS) $(OUTDIR)/RALibretro-*.zip RALibretro-*.zip

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ src/Git.cpp: etc/Git.cpp.template FORCE
 
 zip:
 	rm -f $(OUTDIR)/RALibretro-*.zip RALibretro-*.zip
-	zip -9 RALibretro-`git describe | tr -d "\n"`.zip $(OUTDIR)/RALibretro.exe
+	zip -9 RALibretro-$(ARCH)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RALibretro.exe
 
 clean:
 	rm -f $(OUTDIR)/RALibretro.exe $(OBJS) $(OUTDIR)/RALibretro-*.zip RALibretro-*.zip

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -10,6 +10,9 @@ CXX=g++
 
 ifeq ($(OS),Windows_NT)
   EXE=.exe
+  KERNEL=windows
+else
+  KERNEL := $(shell uname -s)
 endif
 
 # compile flags
@@ -38,9 +41,9 @@ OBJS=\
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-all: $(OUTDIR)/RAHasher$(EXE)
+all: $(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE)
 
-$(OUTDIR)/RAHasher$(EXE): $(OBJS)
+$(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE): $(OBJS)
 	mkdir -p $(OUTDIR)
 	$(CXX) -o $@ $+ $(LDFLAGS)
 
@@ -48,6 +51,6 @@ src/Git.cpp: etc/Git.cpp.template FORCE
 	cat $< | sed s/GITFULLHASH/`git rev-parse HEAD | tr -d "\n"`/g | sed s/GITMINIHASH/`git rev-parse HEAD | tr -d "\n" | cut -c 1-7`/g | sed s/GITRELEASE/`git describe --tags | sed s/\-.*//g | tr -d "\n"`/g > $@
 
 clean:
-	rm -f $(OUTDIR)/RAHasher$(EXE) $(OBJS)
+	rm -f $(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE) $(OBJS)
 
 .PHONY: clean FORCE

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -55,6 +55,6 @@ zip:
 	zip -9 RAHasher-$(ARCH)-$(KERNEL)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RAHasher$(EXE)
 
 clean:
-	rm -f $(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE) $(OBJS)
+	rm -f $(OUTDIR)/RAHasher$(EXE) $(OBJS)
 
 .PHONY: clean FORCE

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -41,14 +41,18 @@ OBJS=\
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-all: $(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE)
+all: $(OUTDIR)/RAHasher$(EXE)
 
-$(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE): $(OBJS)
+$(OUTDIR)/RAHasher$(EXE): $(OBJS)
 	mkdir -p $(OUTDIR)
 	$(CXX) -o $@ $+ $(LDFLAGS)
 
 src/Git.cpp: etc/Git.cpp.template FORCE
 	cat $< | sed s/GITFULLHASH/`git rev-parse HEAD | tr -d "\n"`/g | sed s/GITMINIHASH/`git rev-parse HEAD | tr -d "\n" | cut -c 1-7`/g | sed s/GITRELEASE/`git describe --tags | sed s/\-.*//g | tr -d "\n"`/g > $@
+
+zip:
+	rm -f $(OUTDIR)/RALHasher-*.zip RAHasher-*.zip
+	zip -9 RAHasher-$(ARCH)-$(KERNEL)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RAHasher$(EXE)
 
 clean:
 	rm -f $(OUTDIR)/RAHasher-$(ARCH)-$(KERNEL)$(EXE) $(OBJS)


### PR DESCRIPTION
## Purpose of this PR

Improving the github workflow to automatically deliver built artifacts in the releases page **when a new tag is created**.

Such artifacts are:

- zip files of the cross-compiled version of RALibretro (both x86 and x64)
- zip files with RAHasher for Linux (both x86 and x64)

Here's an example of the results: <https://github.com/meleu/RALibretro/releases/tag/v6.6.6>

## Notes

- I changed the `Makefile` to generate a zip file like `RALibretro-${ARCH}-${GIT_TAG}.zip`
    - e.g.: `RALibretro-x64-v6.6.6.zip`
- I changed the `Makefile.RAHasher` to generate a zip file like `RAHasher-${ARCH}-${OS}-${GIT_TAG}.zip`
  - `${OS}` is either `windows` or the value returned by `uname -s`
  - e.g.: `RAHasher-x64-Linux-v6.6.6.zip`


## :warning: Disclaimer

I didn't test the binaries generated by cross-compilation (I don't have a Windows machine at hand).

If some kind person (@Jamiras, @Sanaki, @televandalist) could confirm the RALibretro binaries are running fine on a Windows machine, that would be appreciated. :heart: 

Download the zip file from here: <https://github.com/meleu/RALibretro/releases/tag/v6.6.6>

