### PR TITLE
deliver RAHasher for Linux on releases page

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,95 +2,117 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master,develop ]
+    branches:
+      - master
+      - develop
+    tags:
+      - "*"
   pull_request:
-    branches: [ master,develop ]
+    branches:
+      - master
+      - develop
 
 jobs:
   RALibretro-Win32:
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
-    - name: Build
-      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install Windows SDK 8.1
+        run: choco install windows-sdk-8.1
+      - name: Build
+        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
 
   RALibretro-Win64:
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
-    - name: Build
-      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install Windows SDK 8.1
+        run: choco install windows-sdk-8.1
+      - name: Build
+        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
 
   RALibretro-Win32-cross-compile:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Install MinGW
-      uses: egor-tensin/setup-mingw@v2
-    - name: Build
-      run: make ARCH=x86
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Install MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Build
+        run: make ARCH=x86
 
   RALibretro-Win64-cross-compile:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Install MinGW
-      uses: egor-tensin/setup-mingw@v2
-    - name: Build
-      run: make ARCH=x64
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Install MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Build
+        run: make ARCH=x64
 
   RAHasher-x86:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
-    - name: Build
-      run: make ARCH=x86 -f Makefile.RAHasher
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
+      - name: Build
+        run: make ARCH=x86 -f Makefile.RAHasher
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x86 -f Makefile.RAHasher zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: RAHasher*.zip
 
   RAHasher-x64:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-multilib # bits/libc-header-start.h
-    - name: Build
-      run: make ARCH=x64 -f Makefile.RAHasher
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-multilib # bits/libc-header-start.h
+      - name: Build
+        run: make ARCH=x64 -f Makefile.RAHasher
+      - name: Zip
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make ARCH=x64 -f Makefile.RAHasher zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: RAHasher*.zip

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,103 +16,105 @@ jobs:
   RALibretro-Win32:
     runs-on: windows-2019
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install MSBuild
-        uses: microsoft/setup-msbuild@v1.0.2
-      - name: Install Windows SDK 8.1
-        run: choco install windows-sdk-8.1
-      - name: Build
-        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Install Windows SDK 8.1
+      run: choco install windows-sdk-8.1
+    - name: Build
+      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
 
   RALibretro-Win64:
     runs-on: windows-2019
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install MSBuild
-        uses: microsoft/setup-msbuild@v1.0.2
-      - name: Install Windows SDK 8.1
-        run: choco install windows-sdk-8.1
-      - name: Build
-        run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Install Windows SDK 8.1
+      run: choco install windows-sdk-8.1
+    - name: Build
+      run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
 
   RALibretro-Win32-cross-compile:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib # bits/libc-header-start.h
-      - name: Install MinGW
-        uses: egor-tensin/setup-mingw@v2
-      - name: Build
-        run: make ARCH=x86
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib # bits/libc-header-start.h
+    - name: Install MinGW
+      uses: egor-tensin/setup-mingw@v2
+    - name: Build
+      run: make ARCH=x86
 
   RALibretro-Win64-cross-compile:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib # bits/libc-header-start.h
-      - name: Install MinGW
-        uses: egor-tensin/setup-mingw@v2
-      - name: Build
-        run: make ARCH=x64
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib # bits/libc-header-start.h
+    - name: Install MinGW
+      uses: egor-tensin/setup-mingw@v2
+    - name: Build
+      run: make ARCH=x64
 
   RAHasher-x86:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
-      - name: Build
-        run: make ARCH=x86 -f Makefile.RAHasher
-      - name: Zip
-        if: startsWith(github.ref, 'refs/tags/')
-        run: make ARCH=x86 -f Makefile.RAHasher zip
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: RAHasher*.zip
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib g++-multilib # bits/libc-header-start.h, bits/c++config.h
+    - name: Build
+      run: make ARCH=x86 -f Makefile.RAHasher
+    - name: Zip
+      if: startsWith(github.ref, 'refs/tags/')
+      run: make ARCH=x86 -f Makefile.RAHasher zip
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: true
+        files: RAHasher*.zip
 
   RAHasher-x64:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib # bits/libc-header-start.h
-      - name: Build
-        run: make ARCH=x64 -f Makefile.RAHasher
-      - name: Zip
-        if: startsWith(github.ref, 'refs/tags/')
-        run: make ARCH=x64 -f Makefile.RAHasher zip
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: RAHasher*.zip
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib # bits/libc-header-start.h
+    - name: Build
+      run: make ARCH=x64 -f Makefile.RAHasher
+    - name: Zip
+      if: startsWith(github.ref, 'refs/tags/')
+      run: make ARCH=x64 -f Makefile.RAHasher zip
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: true
+        files: RAHasher*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 *.swp
 *.log
 *.pdb
+*.zip
 .vs
 /bin
 /bin64
-/RALibretro*.zip
 /obj
 /src/Git.cpp

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -50,11 +50,11 @@ $(OUTDIR)/RAHasher$(EXE): $(OBJS)
 src/Git.cpp: etc/Git.cpp.template FORCE
 	cat $< | sed s/GITFULLHASH/`git rev-parse HEAD | tr -d "\n"`/g | sed s/GITMINIHASH/`git rev-parse HEAD | tr -d "\n" | cut -c 1-7`/g | sed s/GITRELEASE/`git describe --tags | sed s/\-.*//g | tr -d "\n"`/g > $@
 
-zip:
-	rm -f $(OUTDIR)/RALHasher-*.zip RAHasher-*.zip
+zip: $(OUTDIR)/RAHasher$(EXE)
+	rm -f $(OUTDIR)/RAHasher-*.zip RAHasher-*.zip
 	zip -9 RAHasher-$(ARCH)-$(KERNEL)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RAHasher$(EXE)
 
 clean:
-	rm -f $(OUTDIR)/RAHasher$(EXE) $(OBJS)
+	rm -f $(OUTDIR)/RAHasher$(EXE) $(OBJS) $(OUTDIR)/RAHasher*.zip RAHasher*.zip
 
 .PHONY: clean FORCE

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -10,6 +10,9 @@ CXX=g++
 
 ifeq ($(OS),Windows_NT)
   EXE=.exe
+  KERNEL=windows
+else
+  KERNEL := $(shell uname -s)
 endif
 
 # compile flags
@@ -46,6 +49,10 @@ $(OUTDIR)/RAHasher$(EXE): $(OBJS)
 
 src/Git.cpp: etc/Git.cpp.template FORCE
 	cat $< | sed s/GITFULLHASH/`git rev-parse HEAD | tr -d "\n"`/g | sed s/GITMINIHASH/`git rev-parse HEAD | tr -d "\n" | cut -c 1-7`/g | sed s/GITRELEASE/`git describe --tags | sed s/\-.*//g | tr -d "\n"`/g > $@
+
+zip:
+	rm -f $(OUTDIR)/RALHasher-*.zip RAHasher-*.zip
+	zip -9 RAHasher-$(ARCH)-$(KERNEL)-`git describe --tags | sed s/\-.*//g | tr -d "\n"`.zip $(OUTDIR)/RAHasher$(EXE)
 
 clean:
 	rm -f $(OUTDIR)/RAHasher$(EXE) $(OBJS)


### PR DESCRIPTION
Improving the github workflow to automatically deliver RAHasher for Linux in the releases page **when a new tag is created**.