### PR TITLE
add Game Focus indicator to titlebar

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -965,7 +965,8 @@ void Application::updateMenu()
   else if (isGameActive())
   {
     char msg[256];
-    snprintf(msg, sizeof(msg), "%s %s - %s", _core.getSystemInfo()->library_name, _core.getSystemInfo()->library_version, getSystemName(_system));
+    snprintf(msg, sizeof(msg), "%s %s - %s%s", _core.getSystemInfo()->library_name, _core.getSystemInfo()->library_version,
+      getSystemName(_system), _keybinds.hasGameFocus() ? " [Game Focus]" : "");
     RA_UpdateAppTitle(msg);
   }
   else
@@ -2473,6 +2474,10 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
 
   case KeyBinds::Action::kKeyboardInput:
     _input.keyboardEvent(static_cast<enum retro_key>(extra >> 8), static_cast<bool>(extra & 0xFF));
+    break;
+
+  case KeyBinds::Action::kGameFocusToggle:
+    updateMenu();
     break;
   }
 }

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -382,7 +382,7 @@ KeyBinds::Action KeyBinds::translateButtonPress(int button, unsigned* extra)
     case kScreenshot:        return Action::kScreenshot;
 
     // Game Focus
-    case kGameFocusToggle:   _gameFocus = !_gameFocus; return Action::kNothing;
+    case kGameFocusToggle:   _gameFocus = !_gameFocus; return Action::kGameFocusToggle;
 
     default:                 return Action::kNothing;
   }

--- a/src/KeyBinds.h
+++ b/src/KeyBinds.h
@@ -86,6 +86,7 @@ public:
     kReset,
 
     // Keyboard
+    kGameFocusToggle,
     kKeyboardInput  // (extra = key << 8 | pressed)
   };
 
@@ -124,6 +125,8 @@ public:
 
   std::string serializeBindings() const;
   bool deserializeBindings(const char* json);
+
+  bool hasGameFocus() const noexcept { return _gameFocus; }
 
 protected:
   libretro::LoggerComponent* _logger;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32680403/166154063-f6be7e6c-a08a-469c-b72e-d6b61ddda1eb.png)

It would be preferable to just say "Game Focus On" or "Game Focus Off" when using the button like RetroArch does, but RAlibretro still doesn't have any way to show on-screen messages (see #2)