### PR TITLE
enable picodrive for gamegear

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -534,6 +534,11 @@
     "extensions": "32x|bin",
     "systems": [10]
   },
+  "picodrive_libretro":{
+    "name": "PicoDrive",
+    "extensions": "gg",
+    "systems": [15]
+  },
   "play_libretro":{
     "name": "Play!",
     "systems": [21],


### PR DESCRIPTION
It looks like picodrive added gamegear support over a year ago: https://github.com/libretro/libretro-core-info/commit/161089447bf923f34ee877098dbf127cc2e43d7f

Brief testing suggests the core is functional, though discord discussions suggest it may have issues (not just with Game Gear). This PR just add it to the list of available cores for GameGear in RAlibretro. 
