### PR TITLE
Fix rendering in dolphin

### DIFF
--- a/src/Gl.cpp
+++ b/src/Gl.cpp
@@ -57,6 +57,8 @@ static PFNGLRENDERBUFFERSTORAGEPROC s_glRenderbufferStorage;
 
 static PFNGLBLENDEQUATIONEXTPROC s_glBlendEquationEXT;
 
+static PFNGLBINDSAMPLERPROC s_glBindSampler;
+
 static void* getProcAddress(const char* symbol)
 {
   void* address = SDL_GL_GetProcAddress(symbol);
@@ -179,6 +181,8 @@ void Gl::init(libretro::LoggerComponent* logger)
   s_glDeleteRenderbuffers = (PFNGLDELETERENDERBUFFERSPROC)getProcAddress("glDeleteRenderbuffers");
 
   s_glBlendEquationEXT = (PFNGLBLENDEQUATIONEXTPROC)getProcAddress("glBlendEquationEXT");
+
+  s_glBindSampler = (PFNGLBINDSAMPLERPROC)getProcAddress("glBindSampler");
 }
 
 bool Gl::ok()
@@ -600,3 +604,9 @@ void Gl::drawArrays(GLenum mode, GLint first, GLsizei count)
   check(__FUNCTION__);
 }
 
+void Gl::bindSampler(GLuint unit, GLuint sampler)
+{
+  if (!s_ok) return;
+  s_glBindSampler(unit, sampler);
+  check(__FUNCTION__);
+}

--- a/src/Gl.h
+++ b/src/Gl.h
@@ -75,6 +75,8 @@ namespace Gl
   void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
   void drawArrays(GLenum mode, GLint first, GLsizei count);
 
+  void bindSampler(GLuint unit, GLuint sampler);
+
   int getVersion();
 }
 

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -787,5 +787,6 @@ void Video::postHwRenderReset() const
   Gl::disable(GL_BLEND);
   Gl::blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   Gl::blendEquation(GL_FUNC_ADD);
+  Gl::bindSampler(0, 0);
   Gl::clearColor(0.0, 0.0, 0.0, 1.0);
 }

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -440,6 +440,10 @@ error:
 
 void libretro::Core::destroy()
 {
+  if (_needsHardwareRender && _hardwareRenderCallback.context_destroy) {
+    _hardwareRenderCallback.context_destroy();
+  }
+
   if (_gameLoaded)
   {
     _core.unloadGame();


### PR DESCRIPTION
This PR fixes rendering in dolphin by calling `glBindSampler(0, 0)` in `Video::postHwRenderReset()`