### PR TITLE
Fix rendering issues with context management

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1290,6 +1290,7 @@ void Application::unloadCore()
 
   _memory.destroy();
   _core.destroy();
+  _video.reset();
 }
 
 void Application::resetGame()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -87,13 +87,13 @@ bool Application::init(const char* title, int width, int height)
     kAllocatorInited,
     kSdlInited,
     kWindowInited,
-    kGlInited,
     kAudioDeviceInited,
     kFifoInited,
     kAudioInited,
     kInputInited,
     kKeyBindsInited,
     kVideoContextInited,
+    kGlInited,
     kVideoInited
   }
   inited = kNothingInited;
@@ -160,6 +160,7 @@ bool Application::init(const char* title, int width, int height)
   SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+  SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
 
   _window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 
@@ -169,27 +170,7 @@ bool Application::init(const char* title, int width, int height)
     goto error;
   }
 
-  {
-    SDL_GLContext context = SDL_GL_CreateContext(_window);
-
-    if (SDL_GL_MakeCurrent(_window, context) != 0)
-    {
-      _logger.error(TAG "SDL_GL_MakeCurrent: %s", SDL_GetError());
-      goto error;
-    }
-  }
-
   inited = kWindowInited;
-
-  Gl::init(&_logger);
-  GlUtil::init(&_logger);
-
-  if (!Gl::ok())
-  {
-    goto error;
-  }
-
-  inited = kGlInited;
 
   // Init audio
   SDL_AudioSpec want;
@@ -253,6 +234,16 @@ bool Application::init(const char* title, int width, int height)
   }
 
   inited = kVideoContextInited;
+
+  Gl::init(&_logger);
+  GlUtil::init(&_logger);
+
+  if (!Gl::ok())
+  {
+    goto error;
+  }
+
+  inited = kGlInited;
 
   if (!_video.init(&_logger, &_videoContext, &_config))
   {
@@ -318,13 +309,13 @@ error:
   switch (inited)
   {
   case kVideoInited:        _video.destroy();
+  case kGlInited:           // nothing to undo
   case kVideoContextInited: _videoContext.destroy();
   case kKeyBindsInited:     _keybinds.destroy();
   case kInputInited:        _input.destroy();
   case kAudioInited:        _audio.destroy();
   case kFifoInited:         _fifo.destroy();
   case kAudioDeviceInited:  SDL_CloseAudioDevice(_audioDev);
-  case kGlInited:           // nothing to undo
   case kWindowInited:       SDL_DestroyWindow(_window);
   case kSdlInited:          SDL_Quit();
   case kAllocatorInited:    _allocator.destroy();

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -237,6 +237,19 @@ void Video::refresh(const void* data, unsigned width, unsigned height, size_t pi
   }
 }
 
+void Video::reset() {
+  if (_hw.enabled) {
+    if (_hw.frameBuffer != 0)
+    {
+      Gl::deleteRenderbuffers(1, &_hw.renderBuffer);
+      Gl::deleteFramebuffers(1, &_hw.frameBuffer);
+      _hw.renderBuffer = _hw.frameBuffer = 0;
+    }
+    _ctx->resetCoreContext();
+    ensureFramebuffer(_textureWidth, _textureHeight, _pixelFormat, _linearFilter);
+  }
+}
+
 bool Video::supportsContext(enum retro_hw_context_type type)
 {
   switch (type)

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -38,6 +38,7 @@ public:
 
   virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override;
   virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) override;
+  virtual void reset() override;
 
   virtual bool                 supportsContext(enum retro_hw_context_type type) override;
   virtual uintptr_t            getCurrentFramebuffer() override;

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -75,7 +75,6 @@ protected:
   GLuint createTexture(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linear);
   bool ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter);
   bool ensureView(unsigned width, unsigned height, unsigned windowWidth, unsigned windowHeight, bool preserveAspect, Rotation rotation);
-  void postHwRenderReset() const;
 
   libretro::LoggerComponent* _logger;
   libretro::VideoContextComponent* _ctx;

--- a/src/components/VideoContext.cpp
+++ b/src/components/VideoContext.cpp
@@ -19,16 +19,38 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "VideoContext.h"
 
+#define TAG "[CONTEXT] "
+
 bool VideoContext::init(libretro::LoggerComponent* logger, SDL_Window* window)
 {
   _logger = logger;
   _window = window;
+
+  _raContext = SDL_GL_CreateContext(_window);
+  _coreContext = SDL_GL_CreateContext(_window);
+  if (SDL_GL_MakeCurrent(_window, _raContext) != 0)
+  {
+    _logger->error(TAG "SDL_GL_MakeCurrent: %s", SDL_GetError());
+    return false;
+  }
 
   return true;
 }
 
 void VideoContext::destroy()
 {
+}
+
+void VideoContext::enableCoreContext(bool enable)
+{
+  if (enable)
+  {
+    SDL_GL_MakeCurrent(_window, _coreContext);
+  }
+  else
+  {
+    SDL_GL_MakeCurrent(_window, _raContext);
+  }
 }
 
 void VideoContext::swapBuffers()

--- a/src/components/VideoContext.cpp
+++ b/src/components/VideoContext.cpp
@@ -53,6 +53,12 @@ void VideoContext::enableCoreContext(bool enable)
   }
 }
 
+void VideoContext::resetCoreContext() {
+  SDL_GL_MakeCurrent(_window, _raContext);
+  SDL_GL_DeleteContext(_coreContext);
+  _coreContext = SDL_GL_CreateContext(_window);
+}
+
 void VideoContext::swapBuffers()
 {
   SDL_GL_SwapWindow(_window);

--- a/src/components/VideoContext.h
+++ b/src/components/VideoContext.h
@@ -29,9 +29,12 @@ public:
   bool init(libretro::LoggerComponent* logger, SDL_Window* window);
   void destroy();
 
+  virtual void enableCoreContext(bool enable) override;
   virtual void swapBuffers() override;
 
 private:
   libretro::LoggerComponent* _logger;
   SDL_Window* _window;
+  SDL_GLContext _raContext;
+  SDL_GLContext _coreContext;
 };

--- a/src/components/VideoContext.h
+++ b/src/components/VideoContext.h
@@ -30,6 +30,7 @@ public:
   void destroy();
 
   virtual void enableCoreContext(bool enable) override;
+  virtual void resetCoreContext() override;
   virtual void swapBuffers() override;
 
 private:

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -162,6 +162,7 @@ namespace libretro
   {
   public:
     virtual void enableCoreContext(bool enable) = 0;
+    virtual void resetCoreContext() = 0;
     virtual void swapBuffers() = 0;
   };
 
@@ -175,6 +176,7 @@ namespace libretro
 
     virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) = 0;
     virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) = 0;
+    virtual void reset() = 0;
 
     virtual bool                 supportsContext(enum retro_hw_context_type type) = 0;
     virtual uintptr_t            getCurrentFramebuffer() = 0;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -161,6 +161,7 @@ namespace libretro
   class VideoContextComponent
   {
   public:
+    virtual void enableCoreContext(bool enable) = 0;
     virtual void swapBuffers() = 0;
   };
 

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -149,6 +149,9 @@ namespace
   class DummyVideoContext : public libretro::VideoContextComponent
   {
   public:
+    virtual void enableCoreContext(bool enable) override
+    {
+    }
     virtual void swapBuffers() override
     {
     }

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -152,6 +152,9 @@ namespace
     virtual void enableCoreContext(bool enable) override
     {
     }
+    virtual void resetCoreContext() override
+    {
+    }
     virtual void swapBuffers() override
     {
     }
@@ -182,6 +185,10 @@ namespace
       (void)width;
       (void)height;
       (void)pitch;
+    }
+
+    virtual void reset() override
+    {
     }
 
     virtual bool supportsContext(enum retro_hw_context_type type) override


### PR DESCRIPTION
Some rendering issues can be caused by the OpenGL state changes made by the frontend. Using separate OpenGL contexts for the core and for the frontend prevents these kinds of issues.

Before:
![image](https://user-images.githubusercontent.com/975426/222960885-81f895c8-464c-4384-bdc0-a77403200326.png)
After:
![image](https://user-images.githubusercontent.com/975426/222960992-6992b7f4-b055-47ad-8c4d-24b10b637925.png)

More rendering issues are caused by leftover OpenGL state when switching games. Destroying and re-creating the OpenGL state on core shutdown resolves this.

Loading Metroid Prime, then Mario 64
Before:
![image](https://user-images.githubusercontent.com/975426/222961202-03c20cd7-7916-4a13-a15e-8fbc95ac7584.png)
After:
![image](https://user-images.githubusercontent.com/975426/222961276-17ae8231-2a69-493f-a4ec-a84d73d2b66b.png)
