### PR TITLE
Background input

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2061,6 +2061,10 @@ void Application::loadConfiguration()
         {
           return -1;
         }
+        if (ud->self->_config.getBackgroundInput())
+        {
+          ud->self->setBackgroundInput(true);
+        }
       }
 
       return 0;
@@ -2262,6 +2266,10 @@ void Application::handle(const SDL_SysWMEvent* syswm)
 
     case IDM_INPUT_CONTROLLER_2:
       _keybinds.showControllerDialog(_input, 1);
+      break;
+
+    case IDM_INPUT_BACKGROUND_INPUT:
+      toggleBackgroundInput();
       break;
 
     case IDM_VIDEO_CONFIG:
@@ -2548,6 +2556,26 @@ void Application::toggleFastForwarding(unsigned extra)
       SetMenuItemInfo(_menu, IDM_TURBO_GAME, false, &info);
       break;
   }
+}
+
+void Application::toggleBackgroundInput()
+{
+  const bool enabled = !_config.getBackgroundInput();
+  _config.setBackgroundInput(enabled);
+
+  setBackgroundInput(enabled);
+}
+
+void Application::setBackgroundInput(bool enabled)
+{
+  SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, enabled ? "1" : "0");
+
+  MENUITEMINFO info;
+  memset(&info, 0, sizeof(info));
+  info.cbSize = sizeof(info);
+  info.fMask = MIIM_STATE;
+  info.fState = enabled ? MFS_CHECKED : MFS_UNCHECKED;
+  SetMenuItemInfo(_menu, IDM_INPUT_BACKGROUND_INPUT, false, &info);
 }
 
 bool Application::handleArgs(int argc, char* argv[])

--- a/src/Application.h
+++ b/src/Application.h
@@ -74,6 +74,8 @@ public:
 
   void refreshMemoryMap();
 
+  Config& config() { return _config; }
+
 protected:
   struct RecentItem
   {
@@ -121,6 +123,8 @@ protected:
   void        saveConfiguration();
   std::string serializeRecentList();
   void        toggleFastForwarding(unsigned extra);
+  void        toggleBackgroundInput();
+  void        setBackgroundInput(bool enabled);
 
   Fsm _fsm;
   bool lastHardcore;

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -560,6 +560,10 @@ std::string Config::serializeEmulatorSettings()
 
   json.append("\"_fastForwardRatio\":");
   json.append(std::to_string(_fastForwardRatio));
+  json.append(",");
+
+  json.append("\"backgroundInput\":");
+  json.append(_backgroundInput ? "true" : "false");
 
   json.append("}");
   return json;
@@ -589,6 +593,10 @@ bool Config::deserializeEmulatorSettings(const char* json)
       if (ud->key == "_audioWhileFastForwarding")
       {
         ud->self->_audioWhileFastForwarding = num != 0;
+      }
+      else if (ud->key == "backgroundInput")
+      {
+        ud->self->_backgroundInput = num != 0;
       }
     }
     else if (event == JSONSAX_NUMBER)

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -554,11 +554,11 @@ std::string Config::serializeEmulatorSettings()
 {
   std::string json("{");
 
-  json.append("\"_audioWhileFastForwarding\":");
+  json.append("\"audioWhileFastForwarding\":");
   json.append(_audioWhileFastForwarding ? "true" : "false");
   json.append(",");
 
-  json.append("\"_fastForwardRatio\":");
+  json.append("\"fastForwardRatio\":");
   json.append(std::to_string(_fastForwardRatio));
   json.append(",");
 
@@ -590,7 +590,7 @@ bool Config::deserializeEmulatorSettings(const char* json)
     }
     else if (event == JSONSAX_BOOLEAN)
     {
-      if (ud->key == "_audioWhileFastForwarding")
+      if (ud->key == "audioWhileFastForwarding" || ud->key == "_audioWhileFastForwarding")
       {
         ud->self->_audioWhileFastForwarding = num != 0;
       }
@@ -601,7 +601,7 @@ bool Config::deserializeEmulatorSettings(const char* json)
     }
     else if (event == JSONSAX_NUMBER)
     {
-      if (ud->key == "_fastForwardRatio")
+      if (ud->key == "fastForwardRatio" || ud->key == "_fastForwardRatio")
       {
         auto value = strtoul(str, NULL, 10);
         if (value < 2)

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -48,6 +48,9 @@ public:
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
+  virtual bool getBackgroundInput() override { return _backgroundInput; }
+  virtual void setBackgroundInput(bool value) override { _backgroundInput = value; }
+
   virtual bool getFastForwarding() override { return _fastForwarding; }
   virtual void setFastForwarding(bool value) override { _fastForwarding = value; }
 
@@ -144,6 +147,7 @@ protected:
   bool _fastForwarding;
   bool _hadDisallowedSetting;
   bool _audioWhileFastForwarding;
+  bool _backgroundInput;
 
   int _fastForwardRatio;
 

--- a/src/components/Dialog.cpp
+++ b/src/components/Dialog.cpp
@@ -19,6 +19,8 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Dialog.h"
 
+#include "Application.h"
+
 #include <stdint.h>
 
 extern HWND g_mainWindow;
@@ -175,8 +177,18 @@ void Dialog::addEditbox(DWORD id, WORD x, WORD y, WORD w, WORD h, WORD lines, ch
 
 bool Dialog::show()
 {
+  extern Application app;
+  const bool hasBackgroundInput = app.config().getBackgroundInput();
+
+  if (hasBackgroundInput) /* disable background input while dialog is open */
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
+
   _updated = false;
   DialogBoxIndirectParam(NULL, (LPCDLGTEMPLATE)_template, g_mainWindow, s_dialogProc, (LPARAM)this);
+
+  if (hasBackgroundInput)
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
   return _updated;
 }
 

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -148,6 +148,9 @@ namespace libretro
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;
 
+    virtual bool getBackgroundInput() = 0;
+    virtual void setBackgroundInput(bool value) = 0;
+
     virtual bool getFastForwarding() = 0;
     virtual void setFastForwarding(bool value) = 0;
 

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -125,6 +125,16 @@ namespace
       return NULL;
     }
 
+    virtual bool getBackgroundInput() override
+    {
+      return false;
+    }
+
+    virtual void setBackgroundInput(bool value) override
+    {
+      (void)value;
+    }
+
     virtual bool getFastForwarding() override
     {
       return false;

--- a/src/menu.rc
+++ b/src/menu.rc
@@ -106,6 +106,7 @@ main MENU
             MENUITEM "Hot Keys...", IDM_INPUT_CONFIG
             MENUITEM "Controller 1...", IDM_INPUT_CONTROLLER_1
             MENUITEM "Controller 2...", IDM_INPUT_CONTROLLER_2
+            MENUITEM "Background Input", IDM_INPUT_BACKGROUND_INPUT
         }
         MENUITEM "Emulator...", IDM_EMULATOR_CONFIG
         MENUITEM "Saving...", IDM_SAVING_CONFIG

--- a/src/resource.h
+++ b/src/resource.h
@@ -90,3 +90,4 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 #define IDM_MANAGE_CORES                        40016
 #define IDM_SAVING_CONFIG                       40017
 #define IDM_EMULATOR_CONFIG                     40018
+#define IDM_INPUT_BACKGROUND_INPUT              40019


### PR DESCRIPTION
Closes #264

Adds a new option (off by default) to enable joystick input when the main window doesn't have focus.

![image](https://github.com/RetroAchievements/RALibretro/assets/32680403/34924e0a-a420-4b92-bc67-69ba03221f3a)
