### PR TITLE
add missing comma

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -752,7 +752,7 @@
   "wasm4_libretro":{
     "name": "WASM-4",
     "systems": [72]
-  }
+  },
   "x1_libretro":{
     "name": "X1",
     "systems": [64],


### PR DESCRIPTION
Fixes a JSON parse error that prevents the Yabause core from being visible.