### PR TITLE
Log and ignore OpenGL errors from core

### DIFF
--- a/src/Gl.cpp
+++ b/src/Gl.cpp
@@ -82,29 +82,7 @@ static void check(const char* function, bool ok = true)
 
     do
     {
-      switch (err)
-      {
-      case GL_INVALID_OPERATION:
-        s_logger->error(TAG "  INVALID_OPERATION");
-        break;
-
-      case GL_INVALID_ENUM:
-        s_logger->error(TAG "  INVALID_ENUM");
-        break;
-
-      case GL_INVALID_VALUE:
-        s_logger->error(TAG "  INVALID_VALUE");
-        break;
-
-      case GL_OUT_OF_MEMORY:
-        s_logger->error(TAG "  OUT_OF_MEMORY");
-        break;
-
-      case GL_INVALID_FRAMEBUFFER_OPERATION:
-        s_logger->error(TAG "  INVALID_FRAMEBUFFER_OPERATION");
-        break;
-      }
-
+      s_logger->error(TAG "  %s", Gl::getErrorMsg(err));
       err = glGetError();
     } while (err != GL_NO_ERROR);
   }
@@ -193,6 +171,29 @@ bool Gl::ok()
 GLenum Gl::getError()
 {
   return glGetError();
+}
+
+const char* Gl::getErrorMsg(GLenum error)
+{
+  switch (error)
+  {
+  case GL_INVALID_ENUM:
+    return "INVALID_ENUM";
+  case GL_INVALID_VALUE:
+    return "INVALID_VALUE";
+  case GL_INVALID_OPERATION:
+    return "INVALID_OPERATION";
+  case GL_STACK_OVERFLOW:
+    return "STACK_OVERFLOW";
+  case GL_STACK_UNDERFLOW:
+    return "STACK_UNDERFLOW";
+  case GL_OUT_OF_MEMORY:
+    return "OUT_OF_MEMORY";
+  case GL_INVALID_FRAMEBUFFER_OPERATION:
+    return "INVALID_FRAMEBUFFER_OPERATION";
+  default:
+    return "Unknown";
+  }
 }
 
 int Gl::getVersion()

--- a/src/Gl.h
+++ b/src/Gl.h
@@ -10,6 +10,7 @@ namespace Gl
   bool ok();
 
   GLenum getError();
+  const char* getErrorMsg(GLenum error);
   void getIntegerv(GLenum pname, GLint *params);
 
   void genTextures(GLsizei n, GLuint* textures);

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -236,6 +236,7 @@ void Video::refresh(const void* data, unsigned width, unsigned height, size_t pi
   }
   else if (_hw.enabled && data == RETRO_HW_FRAME_BUFFER_VALID)
   {
+    clearErrors();
     _ctx->enableCoreContext(false);
     ensureView(width, height, _windowWidth, _windowHeight, _preserveAspect, _rotation);
     draw();
@@ -798,4 +799,11 @@ bool Video::ensureView(unsigned width, unsigned height, unsigned windowWidth, un
   }
 
   return true;
+}
+
+void Video::clearErrors() {
+  for (GLenum error = Gl::getError(); error != GL_NO_ERROR; error = Gl::getError())
+  {
+    _logger->error(TAG "Unhandled OpenGL error from core: %s", Gl::getErrorMsg(error));
+  }
 }

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -78,6 +78,7 @@ protected:
   GLuint createTexture(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linear);
   bool ensureFramebuffer(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linearFilter);
   bool ensureView(unsigned width, unsigned height, unsigned windowWidth, unsigned windowHeight, bool preserveAspect, Rotation rotation);
+  void clearErrors();
 
   libretro::LoggerComponent* _logger;
   libretro::VideoContextComponent* _ctx;


### PR DESCRIPTION
This prevents issues with core shutdown caused by OpenGL errors that occur within a core