### PR TITLE
support for numeric prefixes on state files in load state dialog

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1801,9 +1801,9 @@ void Application::loadState(unsigned ndx)
 
 void Application::loadState()
 {
-  std::string extensions = "State Files (*.state)";
+  std::string extensions = "State Files (*.state*)";
   extensions.append("\0", 1);
-  extensions.append("*.state");
+  extensions.append("*.state*");
   extensions.append("\0", 1);
   extensions.append("All Files (*.*)");
   extensions.append("\0", 1);


### PR DESCRIPTION
Fixes a long-standing discrepancy introduced by #265. 

> Additionally, the filename format has been changed from "GameName.001.state" to "GameName.state1" to match RetroArch

However, the Load State dialog was not updated to match numeric state files, so the user has to select "All Files" to find them.

This fixes that.