### PR TITLE
add warning when loading old core

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -656,7 +656,7 @@ static void getCoreSystemTimes(Config* config, Logger* logger)
   }
 }
 
-bool showCoresDialog(Config* config, Logger* logger, const std::string& loadedCore)
+bool showCoresDialog(Config* config, Logger* logger, const std::string& loadedCore, int selectedSystem)
 {
   CoreDialog db;
   db.init("Manage Cores");
@@ -687,15 +687,22 @@ bool showCoresDialog(Config* config, Logger* logger, const std::string& loadedCo
     }
   }
 
+  int selectedCoreIndex = 0;
+
+  // allSystems is a std::map keyed on the system name. iterating it will result in an alphabetically sorted list.
   for (const auto& pair : allSystems)
+  {
+    if (pair.second == selectedSystem)
+      selectedCoreIndex = db.numSystems;
+
     db.systemIds[db.numSystems++] = pair.second;
+  }
 
   db.coreNames.resize(maxSystemCoreCount);
 
   const DWORD WIDTH = 420;
   WORD y = 0;
 
-  int selectedCoreIndex = 0;
   db.addCombobox(50000, 0, 0, 200, 16, 120, s_getCoreName, &db, &selectedCoreIndex);
   y += 20;
 

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -40,4 +40,4 @@ int    encodeCoreName(const std::string& coreName, int system);
 const std::string& getCoreName(int encoded, int& systemOut);
 const std::string* getCoreDeprecationMessage(const std::string& coreName);
 
-bool   showCoresDialog(Config* config, Logger* logger, const std::string& loadedCoreName);
+bool   showCoresDialog(Config* config, Logger* logger, const std::string& loadedCoreName, int selectedSystem);


### PR DESCRIPTION
When selecting a core from the "Select Core" menu, it's last updated timestamp will be compared to the current time. If the timestamp is more than 365 days old, a popup will appear informing the user that they're on an old core:
![image](https://github.com/RetroAchievements/RALibretro/assets/32680403/41b6d320-fa19-4f6d-8bc5-24b761d665fc)

Clicking 'Yes' will open the Manage Cores dialog where the user can download the newest available version. Clicking 'No' will dismiss the dialog and the old core will continue to be used.

The check does not occur when opening games from the "Load Recent" menu as upgrading the core may cause save states to become invalid. 