### PR TITLE
implement RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ OBJS=\
 	src/components/Dialog.o \
 	src/components/Input.o \
 	src/components/Logger.o \
+	src/components/Microphone.o \
 	src/components/Video.o \
 	src/components/VideoContext.o \
 	src/miniz/miniz.o \

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -73,6 +73,7 @@ Application::Application(): _fsm(*this)
   _components.videoContext = &_videoContext;
   _components.video        = &_video;
   _components.audio        = &_audio;
+  _components.microphone   = &_microphone;
   _components.input        = &_input;
   _components.allocator    = &_allocator;
 }
@@ -259,6 +260,11 @@ bool Application::init(const char* title, int width, int height)
     goto error;
   }
 
+  if (!_microphone.init(&_logger))
+  {
+    goto error;
+  }
+
   inited = kAudioInited;
 
   if (!_input.init(&_logger))
@@ -334,7 +340,8 @@ error:
   case kInputInited:        _input.destroy();
   case kAudioInited:        _audio.destroy();
   case kFifoInited:         _fifo.destroy();
-  case kAudioDeviceInited:  SDL_CloseAudioDevice(_audioDev);
+  case kAudioDeviceInited:  _microphone.destroy();
+                            SDL_CloseAudioDevice(_audioDev);
   case kWindowInited:       SDL_DestroyWindow(_window);
   case kKeyBindsInited:     _keybinds.destroy();
   case kSdlInited:          SDL_Quit();
@@ -692,6 +699,7 @@ void Application::destroy()
   _keybinds.destroy();
   _input.destroy();
   _config.destroy();
+  _microphone.destroy();
   _audio.destroy();
   _fifo.destroy();
 
@@ -1402,6 +1410,19 @@ bool Application::isGameActive()
   case Fsm::State::GamePaused:
   case Fsm::State::GamePausedNoOvl:
   case Fsm::State::FrameStep:
+    return true;
+
+  default:
+    return false;
+  }
+}
+
+bool Application::isPaused() const
+{
+  switch (_fsm.currentState())
+  {
+  case Fsm::State::GamePaused:
+  case Fsm::State::GamePausedNoOvl:
     return true;
 
   default:
@@ -2165,14 +2186,15 @@ void Application::resizeWindow(int width, int height)
 void Application::toggleFullscreen()
 {
   Uint32 fullscreen = SDL_GetWindowFlags(_window) & SDL_WINDOW_FULLSCREEN_DESKTOP;
-  SDL_SetWindowFullscreen(_window, fullscreen ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
-  
   if (fullscreen)
   {
     SetMenu(g_mainWindow, _menu);
     SDL_ShowCursor(SDL_ENABLE);
   }
-  else
+
+  SDL_SetWindowFullscreen(_window, fullscreen ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
+
+  if (!fullscreen)
   {
     SetMenu(g_mainWindow, NULL);
     SDL_ShowCursor(SDL_DISABLE);

--- a/src/Application.h
+++ b/src/Application.h
@@ -32,6 +32,7 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 #include "components/Config.h"
 #include "components/Input.h"
 #include "components/Logger.h"
+#include "components/Microphone.h"
 #include "components/VideoContext.h"
 #include "components/Video.h"
 
@@ -61,6 +62,7 @@ public:
   bool hardcore();
   bool unloadGame();
   void pauseGame(bool pause);
+  bool isPaused() const;
 
   void printf(const char* fmt, ...);
   Logger& logger() { return _logger; }
@@ -143,6 +145,7 @@ protected:
   VideoContext _videoContext;
   Video        _video;
   Audio        _audio;
+  Microphone   _microphone;
   Input        _input;
   Memory       _memory;
   States       _states;

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -189,6 +189,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)\bin64</Command>
     <ClCompile Include="components\Dialog.cpp" />
     <ClCompile Include="components\Input.cpp" />
     <ClCompile Include="components\Logger.cpp" />
+    <ClCompile Include="components\Microphone.cpp" />
     <ClCompile Include="components\Video.cpp" />
     <ClCompile Include="components\VideoContext.cpp" />
     <ClCompile Include="dynlib\dynlib.c" />

--- a/src/RALibretro.vcxproj.filters
+++ b/src/RALibretro.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="HashCHD.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="components\Microphone.cpp">
+      <Filter>Source Files\components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="About.h">

--- a/src/components/Audio.cpp
+++ b/src/components/Audio.cpp
@@ -272,7 +272,7 @@ void Audio::mix(const int16_t* samples, size_t frames)
       if (error != RESAMPLER_ERR_SUCCESS)
       {
         memset(output, 0, output_size);
-        _logger->error(TAG "speex_resampler_process_interleaved_int: %s", speex_resampler_strerror(error));
+        _logger->error(TAG "speex_resampler_process_int: %s", speex_resampler_strerror(error));
       }
     }
   }

--- a/src/components/Microphone.cpp
+++ b/src/components/Microphone.cpp
@@ -24,6 +24,8 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 #include <SDL_audio.h>
 #include "speex/speex_resampler.h"
 
+#include <math.h>
+
 #define TAG "[MIC] "
 
 struct Microphone::SDLData

--- a/src/components/Microphone.cpp
+++ b/src/components/Microphone.cpp
@@ -1,0 +1,271 @@
+/*
+Copyright (C) 2023 Brian Weiss
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Microphone.h"
+
+#include "Application.h"
+
+#include <SDL_audio.h>
+#include "speex/speex_resampler.h"
+
+#define TAG "[MIC] "
+
+struct Microphone::SDLData
+{
+  SDL_AudioDeviceID deviceId;
+  SDL_AudioSpec deviceSpec;
+  unsigned coreRate;
+  bool enabled;
+  Fifo fifo;
+  libretro::LoggerComponent* logger;
+  SpeexResamplerState* resampler;
+};
+
+bool Microphone::init(libretro::LoggerComponent* logger)
+{
+  _logger = logger;
+  return true;
+}
+
+void Microphone::destroy()
+{
+  if (_data)
+    closeMic((retro_microphone_t*)_data);
+}
+
+void Microphone::recordCallback(void* data, Uint8* stream, int len)
+{
+  SDLData* sdlData = (SDLData*)data;
+
+  if (!sdlData->enabled) /* don't fill buffer when mic is not active, nothing is going to read the buffer */
+    return;
+
+  extern Application app;
+  if (app.isPaused()) /* don't fill buffer while paused, nothing is running to empty buffer */
+    return;
+
+  int frames = len / sizeof(int16_t);
+  int16_t* samples = (int16_t*)stream;
+
+  size_t output_size;
+  int16_t* output;
+
+  if (sdlData->deviceSpec.freq == sdlData->coreRate)
+  {
+    /* no resampling needed */
+    output = (int16_t*)samples;
+    output_size = frames * sizeof(int16_t);
+  }
+  else
+  {
+    /* allocate output buffer */
+    spx_uint32_t out_len = (spx_uint32_t)ceil(frames * sdlData->coreRate / sdlData->deviceSpec.freq);
+    output_size = out_len * sizeof(int16_t);
+    output = (int16_t*)alloca(output_size);
+
+    if (output == NULL)
+    {
+      sdlData->logger->error(TAG "Error allocating audio resampling output buffer");
+      return;
+    }
+
+    /* do the resampling */
+    int error;
+    if (!sdlData->resampler)
+    {
+      sdlData->resampler = speex_resampler_init(1, sdlData->deviceSpec.freq, sdlData->coreRate, SPEEX_RESAMPLER_QUALITY_DEFAULT, &error);
+
+      if (!sdlData->resampler)
+      {
+        sdlData->logger->error(TAG "speex_resampler_init: %s", speex_resampler_strerror(error));
+        SDL_PauseAudioDevice(sdlData->deviceId, true);
+        return;
+      }
+    }
+
+    spx_uint32_t in_frames = frames;
+    spx_uint32_t out_frames = out_len;
+    sdlData->logger->debug(TAG "Resampling %u samples to %u", in_frames, out_frames);
+    error = speex_resampler_process_int(sdlData->resampler, 0, (const int16_t*)samples, &in_frames, output, &out_frames);
+    if (error == RESAMPLER_ERR_SUCCESS)
+    {
+      /* update with the actual number of frames created */
+      output_size = out_frames * sizeof(int16_t);
+    }
+    else
+    {
+      memset(output, 0, output_size);
+      sdlData->logger->error(TAG "speex_resampler_process_int: %s", speex_resampler_strerror(error));
+    }
+  }
+
+  /* flush to FIFO queue */
+  size_t avail = sdlData->fifo.free();
+  if (avail < output_size)
+  {
+    sdlData->logger->debug(TAG "Waiting for FIFO (need %zu bytes but only %zu available), sleeping", output_size, avail);
+
+    const int MAX_WAIT = 250;
+    int tries = MAX_WAIT;
+    do
+    {
+      SDL_Delay(1);
+      if (!sdlData->enabled)
+        return;
+
+      avail = sdlData->fifo.free();
+      if (avail >= output_size)
+        break;
+
+      /* prevent infinite loop if fifo full */
+      if (--tries == 0)
+      {
+        sdlData->logger->debug(TAG "FIFO still full after %dms, flushing", MAX_WAIT);
+        sdlData->fifo.reset();
+        avail = sdlData->fifo.free();
+        break;
+      }
+    } while (true);
+
+    if (avail < output_size)
+      output_size = avail;
+  }
+
+  sdlData->fifo.write(output, output_size);
+}
+
+retro_microphone_t* Microphone::openMic(const retro_microphone_params_t* params)
+{
+  if (_data != NULL) /* only one microphone allowed at a time*/
+    return NULL;
+
+  SDLData* data = new SDLData();
+  if (data == NULL)
+    return NULL;
+
+  data->logger = _logger;
+  data->resampler = nullptr;
+  data->coreRate = params->rate;
+  data->enabled = false;
+
+  SDL_AudioSpec desired_spec {};
+  desired_spec.freq = params->rate;
+  desired_spec.format = AUDIO_S16SYS;
+  desired_spec.channels = 1; /* Microphones only usually provide input in mono */
+  desired_spec.samples = 2048;
+  desired_spec.userdata = data;
+  desired_spec.callback = recordCallback;
+
+  data->deviceId = SDL_OpenAudioDevice(NULL, true, &desired_spec, &data->deviceSpec,
+      SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+
+  if (data->deviceId == 0)
+  {
+    _logger->error(TAG "Failed to open SDL audio input device: %s", SDL_GetError());
+    delete data;
+    return NULL;
+  }
+
+  _logger->info(TAG "Opened microphone with ID %u (frequency %u [requested %u])", data->deviceId, data->deviceSpec.freq, desired_spec.freq);
+  _logger->info(TAG "Microphone audio format: %u-bit %s %s %s endian\n",
+                SDL_AUDIO_BITSIZE(data->deviceSpec.format),
+                SDL_AUDIO_ISSIGNED(data->deviceSpec.format) ? "signed" : "unsigned",
+                SDL_AUDIO_ISFLOAT(data->deviceSpec.format) ? "floating-point" : "integer",
+                SDL_AUDIO_ISBIGENDIAN(data->deviceSpec.format) ? "big" : "little");
+
+  data->fifo.init(data->deviceSpec.size * 4);
+  _data = data;
+  return (retro_microphone_t*)data;
+}
+
+void Microphone::closeMic(retro_microphone_t* microphone)
+{
+  if ((SDLData*)microphone == _data)
+  {
+    SDL_CloseAudioDevice(_data->deviceId);
+    _data->fifo.destroy();
+
+    if (_data->resampler != NULL)
+      speex_resampler_destroy(_data->resampler);
+
+    delete _data;
+    _data = NULL;
+  }
+}
+
+bool Microphone::getMicParams(const retro_microphone_t* microphone, retro_microphone_params_t* params)
+{
+  if (!_data)
+    return false;
+
+  params->rate = _data->deviceSpec.freq;
+  return true;
+}
+
+bool Microphone::getMicState(const retro_microphone_t* microphone)
+{
+  return _data && _data->enabled;
+}
+
+bool Microphone::setMicState(retro_microphone_t* microphone, bool state)
+{
+  if (!_data)
+    return false;
+
+  SDL_PauseAudioDevice(_data->deviceId, !state);
+  if (state)
+  {
+    if (SDL_GetAudioDeviceStatus(_data->deviceId) != SDL_AUDIO_PLAYING)
+    {
+      _logger->warn(TAG "Failed to start microphone %u: %s", _data->deviceId, SDL_GetError());
+      return false;
+    }
+  }
+  else
+  {
+    switch (SDL_GetAudioDeviceStatus(_data->deviceId))
+    {
+    case SDL_AUDIO_PLAYING:
+      _logger->warn(TAG "Failed to pause microphone %u: %s", _data->deviceId, SDL_GetError());
+      return false;
+    case SDL_AUDIO_STOPPED:
+      _logger->warn(TAG "Microphone %u has been stopped and may not start again: %s", _data->deviceId, SDL_GetError());
+      return false;
+    default:
+      break;
+    }
+
+    _data->fifo.reset();
+  }
+
+  _data->enabled = state;
+  return true;
+}
+
+int Microphone::readMic(retro_microphone_t* microphone, int16_t* frames, size_t num_frames)
+{
+  if (!_data || !_data->enabled)
+    return 0;
+
+  size_t num_read = std::min(num_frames, _data->fifo.occupied() / sizeof(int16_t));
+  _data->fifo.read(frames, num_read * sizeof(int16_t));
+  return (int)num_read;
+}
+
+

--- a/src/components/Microphone.h
+++ b/src/components/Microphone.h
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2023 Brian Weiss
+
+This file is part of RALibretro.
+
+RALibretro is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RALibretro is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "libretro/Components.h"
+
+#include "libretro/libretro.h"
+#include "Audio.h"
+
+class Microphone : public libretro::MicrophoneComponent
+{
+public:
+  bool init(libretro::LoggerComponent* logger);
+  void destroy();
+
+  virtual retro_microphone_t* openMic(const retro_microphone_params_t* params) override;
+  virtual void closeMic(retro_microphone_t* microphone) override;
+  virtual bool getMicParams(const retro_microphone_t* microphone, retro_microphone_params_t* params) override;
+  virtual bool getMicState(const retro_microphone_t* microphone) override;
+  virtual bool setMicState(retro_microphone_t* microphone, bool state) override;
+  virtual int readMic(retro_microphone_t* microphone, int16_t* frames, size_t num_frames) override;
+
+protected:
+  libretro::LoggerComponent* _logger;
+
+  Fifo* _fifo;
+
+  struct SDLData;
+  struct SDLData* _data;
+
+  static void recordCallback(void* data, Uint8* stream, int len);
+};

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -211,6 +211,20 @@ namespace libretro
   };
 
   /**
+   * A microphone component.
+   */
+  class MicrophoneComponent
+  {
+  public:
+    virtual retro_microphone_t* openMic(const retro_microphone_params_t* params) = 0;
+    virtual void closeMic(retro_microphone_t* microphone) = 0;
+    virtual bool getMicParams(const retro_microphone_t* microphone, retro_microphone_params_t* params) = 0;
+    virtual bool getMicState(const retro_microphone_t* microphone) = 0;
+    virtual bool setMicState(retro_microphone_t* microphone, bool state) = 0;
+    virtual int readMic(retro_microphone_t* microphone, int16_t* frames, size_t num_frames) = 0;
+  };
+
+  /**
    * A component that provides input state to CoreWrap instances.
    */
   class InputComponent
@@ -248,6 +262,7 @@ namespace libretro
     VideoContextComponent* videoContext;
     VideoComponent*        video;
     AudioComponent*        audio;
+    MicrophoneComponent*   microphone;
     InputComponent*        input;
     AllocatorComponent*    allocator;
   };

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -174,6 +174,7 @@ namespace libretro
     bool setCoreOptionsV2Intl(const struct retro_core_options_v2_intl* data);
     bool setCoreOptionsDisplay(const struct retro_core_option_display* data);
     bool getPreferredHWRender(unsigned* data);
+    bool getMicrophoneInterface(struct retro_microphone_interface* data);
 
     // Callbacks
     bool                 environmentCallback(unsigned cmd, void* data);
@@ -200,12 +201,19 @@ namespace libretro
     static void                 s_logCallback(enum retro_log_level level, const char *fmt, ...);
     static bool                 s_setRumbleCallback(unsigned port, enum retro_rumble_effect effect, uint16_t strength);
     static void                 s_setLEDState(int led, int state);
+    static retro_microphone_t*  s_openMic(const retro_microphone_params_t* params);
+    static void                 s_closeMic(retro_microphone_t* microphone);
+    static bool                 s_getMicParams(const retro_microphone_t* microphone, retro_microphone_params_t* params);
+    static bool                 s_getMicState(const retro_microphone_t* microphone);
+    static bool                 s_setMicState(retro_microphone_t* microphone, bool state);
+    static int                  s_readMic(retro_microphone_t* microphone, int16_t* frames, size_t num_frames);
 
     LoggerComponent*                _logger;
     ConfigComponent*                _config;
     VideoContextComponent*          _videoContext;
     VideoComponent*                 _video;
     AudioComponent*                 _audio;
+    MicrophoneComponent*            _microphone;
     InputComponent*                 _input;
     AllocatorComponent*             _allocator;
         

--- a/src/libretro/libretro.h
+++ b/src/libretro/libretro.h
@@ -283,6 +283,15 @@ enum retro_language
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_FINNISH             = 23,
+   RETRO_LANGUAGE_INDONESIAN          = 24,
+   RETRO_LANGUAGE_SWEDISH             = 25,
+   RETRO_LANGUAGE_UKRAINIAN           = 26,
+   RETRO_LANGUAGE_CZECH               = 27,
+   RETRO_LANGUAGE_CATALAN_VALENCIA    = 28,
+   RETRO_LANGUAGE_CATALAN             = 29,
+   RETRO_LANGUAGE_BRITISH_ENGLISH     = 30,
+   RETRO_LANGUAGE_HUNGARIAN           = 31,
+   RETRO_LANGUAGE_BELARUSIAN          = 32,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -920,8 +929,6 @@ enum retro_mod
                                             * anything else.
                                             * It is recommended to expose all relevant pointers through
                                             * retro_get_memory_* as well.
-                                            *
-                                            * Can be called from retro_init and retro_load_game.
                                             */
 #define RETRO_ENVIRONMENT_SET_GEOMETRY 37
                                            /* const struct retro_game_geometry * --
@@ -1722,6 +1729,127 @@ enum retro_mod
                                             * Must be called in retro_set_environment().
                                             */
 
+#define RETRO_ENVIRONMENT_SET_VARIABLE 70
+                                           /* const struct retro_variable * --
+                                            * Allows an implementation to notify the frontend
+                                            * that a core option value has changed.
+                                            *
+                                            * retro_variable::key and retro_variable::value
+                                            * must match strings that have been set previously
+                                            * via one of the following:
+                                            *
+                                            * - RETRO_ENVIRONMENT_SET_VARIABLES
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL
+                                            *
+                                            * After changing a core option value via this
+                                            * callback, RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
+                                            * will return true.
+                                            *
+                                            * If data is NULL, no changes will be registered
+                                            * and the callback will return true; an
+                                            * implementation may therefore pass NULL in order
+                                            * to test whether the callback is supported.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (71 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_throttle_state * --
+                                            * Allows an implementation to get details on the actual rate
+                                            * the frontend is attempting to call retro_run().
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_SAVESTATE_CONTEXT (72 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* int * --
+                                            * Tells the core about the context the frontend is asking for savestate.
+                                            * (see enum retro_savestate_context)
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_SUPPORT (73 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* struct retro_hw_render_context_negotiation_interface * --
+                                             * Before calling SET_HW_RNEDER_CONTEXT_NEGOTIATION_INTERFACE, a core can query
+                                             * which version of the interface is supported.
+                                             *
+                                             * Frontend looks at interface_type and returns the maximum supported
+                                             * context negotiation interface version.
+                                             * If the interface_type is not supported or recognized by the frontend, a version of 0
+                                             * must be returned in interface_version and true is returned by frontend.
+                                             *
+                                             * If this environment call returns true with interface_version greater than 0,
+                                             * a core can always use a negotiation interface version larger than what the frontend returns, but only
+                                             * earlier versions of the interface will be used by the frontend.
+                                             * A frontend must not reject a negotiation interface version that is larger than
+                                             * what the frontend supports. Instead, the frontend will use the older entry points that it recognizes.
+                                             * If this is incompatible with a particular core's requirements, it can error out early.
+                                             *
+                                             * Backwards compatibility note:
+                                             * This environment call was introduced after Vulkan v1 context negotiation.
+                                             * If this environment call is not supported by frontend - i.e. the environment call returns false -
+                                             * only Vulkan v1 context negotiation is supported (if Vulkan HW rendering is supported at all).
+                                             * If a core uses Vulkan negotiation interface with version > 1, negotiation may fail unexpectedly.
+                                             * All future updates to the context negotiation interface implies that frontend must support
+                                             * this environment call to query support.
+                                             */
+
+#define RETRO_ENVIRONMENT_GET_JIT_CAPABLE 74
+                                           /* bool * --
+                                            * Result is set to true if the frontend has already verified JIT can be
+                                            * used, mainly for use iOS/tvOS. On other platforms the result is true.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE (75 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_microphone_interface * --
+                                            * Returns an interface that can be used to receive input from the microphone driver.
+                                            *
+                                            * Returns true if microphone support is available,
+                                            * even if no microphones are plugged in.
+                                            * Returns false if mic support is disabled or unavailable.
+                                            *
+                                            * This callback can be invoked at any time,
+                                            * even before the microphone driver is ready.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE 76
+                                           /* const struct retro_netpacket_callback * --
+                                            * When set, a core gains control over network packets sent and
+                                            * received during a multiplayer session. This can be used to
+                                            * emulate multiplayer games that were originally played on two
+                                            * or more separate consoles or computers connected together.
+                                            *
+                                            * The frontend will take care of connecting players together,
+                                            * and the core only needs to send the actual data as needed for
+                                            * the emulation, while handshake and connection management happen
+                                            * in the background.
+                                            *
+                                            * When two or more players are connected and this interface has
+                                            * been set, time manipulation features (such as pausing, slow motion,
+                                            * fast forward, rewinding, save state loading, etc.) are disabled to
+                                            * avoid interrupting communication.
+                                            *
+                                            * Should be set in either retro_init or retro_load_game, but not both.
+                                            *
+                                            * When not set, a frontend may use state serialization-based
+                                            * multiplayer, where a deterministic core supporting multiple
+                                            * input devices does not need to take any action on its own.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DEVICE_POWER (77 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_device_power * --
+                                            * Returns the device's current power state as reported by the frontend.
+                                            * This is useful for emulating the battery level in handheld consoles,
+                                            * or for reducing power consumption when on battery power.
+                                            *
+                                            * The return value indicates whether the frontend can provide this information,
+                                            * even if the parameter is NULL.
+                                            *
+                                            * If the frontend does not support this functionality,
+                                            * then the provided argument will remain unchanged.
+                                            *
+                                            * Note that this environment call describes the power state for the entire device,
+                                            * not for individual peripherals like controllers.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -1896,13 +2024,13 @@ struct retro_vfs_interface_info
 
 enum retro_hw_render_interface_type
 {
-	RETRO_HW_RENDER_INTERFACE_VULKAN = 0,
-	RETRO_HW_RENDER_INTERFACE_D3D9   = 1,
-	RETRO_HW_RENDER_INTERFACE_D3D10  = 2,
-	RETRO_HW_RENDER_INTERFACE_D3D11  = 3,
-	RETRO_HW_RENDER_INTERFACE_D3D12  = 4,
+   RETRO_HW_RENDER_INTERFACE_VULKAN     = 0,
+   RETRO_HW_RENDER_INTERFACE_D3D9       = 1,
+   RETRO_HW_RENDER_INTERFACE_D3D10      = 2,
+   RETRO_HW_RENDER_INTERFACE_D3D11      = 3,
+   RETRO_HW_RENDER_INTERFACE_D3D12      = 4,
    RETRO_HW_RENDER_INTERFACE_GSKIT_PS2  = 5,
-   RETRO_HW_RENDER_INTERFACE_DUMMY  = INT_MAX
+   RETRO_HW_RENDER_INTERFACE_DUMMY      = INT_MAX
 };
 
 /* Base struct. All retro_hw_render_interface_* types
@@ -2678,9 +2806,17 @@ enum retro_hw_context_type
    /* Vulkan, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE. */
    RETRO_HW_CONTEXT_VULKAN           = 6,
 
-   /* Direct3D, set version_major to select the type of interface
-    * returned by RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
-   RETRO_HW_CONTEXT_DIRECT3D         = 7,
+   /* Direct3D11, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
+   RETRO_HW_CONTEXT_D3D11            = 7,
+
+   /* Direct3D10, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
+   RETRO_HW_CONTEXT_D3D10            = 8,
+
+   /* Direct3D12, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
+   RETRO_HW_CONTEXT_D3D12            = 9,
+
+   /* Direct3D9, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
+   RETRO_HW_CONTEXT_D3D9             = 10,
 
    RETRO_HW_CONTEXT_DUMMY = INT_MAX
 };
@@ -2935,6 +3071,100 @@ struct retro_disk_control_ext_callback
    retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
+/* Definitions for RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE.
+ * A core can set it if sending and receiving custom network packets
+ * during a multiplayer session is desired.
+ */
+
+/* Netpacket flags for retro_netpacket_send_t */
+#define RETRO_NETPACKET_UNRELIABLE  0        /* Packet to be sent unreliable, depending on network quality it might not arrive. */
+#define RETRO_NETPACKET_RELIABLE    (1 << 0) /* Reliable packets are guaranteed to arrive at the target in the order they were send. */
+#define RETRO_NETPACKET_UNSEQUENCED (1 << 1) /* Packet will not be sequenced with other packets and may arrive out of order. Cannot be set on reliable packets. */
+
+/* Used by the core to send a packet to one or more connected players.
+ * A single packet sent via this interface can contain up to 64 KB of data.
+ *
+ * The broadcast flag can be set to true to send to multiple connected clients.
+ * In a broadcast, the client_id argument indicates 1 client NOT to send the
+ * packet to (pass 0xFFFF to send to everyone). Otherwise, the client_id
+ * argument indicates a single client to send the packet to.
+ *
+ * A frontend must support sending reliable packets (RETRO_NETPACKET_RELIABLE).
+ * Unreliable packets might not be supported by the frontend, but the flags can
+ * still be specified. Reliable transmission will be used instead.
+ *
+ * If this function is called passing NULL for buf, it will instead flush all
+ * previously buffered outgoing packets and instantly read any incoming packets.
+ * During such a call, retro_netpacket_receive_t and retro_netpacket_stop_t can
+ * be called. The core can perform this in a loop to do a blocking read, i.e.,
+ * wait for incoming data, but needs to handle stop getting called and also
+ * give up after a short while to avoid freezing on a connection problem.
+ *
+ * This function is not guaranteed to be thread-safe and must be called during
+ * retro_run or any of the netpacket callbacks passed with this interface.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_send_t)(int flags, const void* buf, size_t len, uint16_t client_id, bool broadcast);
+
+/* Called by the frontend to signify that a multiplayer session has started.
+ * If client_id is 0 the local player is the host of the session and at this
+ * point no other player has connected yet.
+ *
+ * If client_id is > 0 the local player is a client connected to a host and
+ * at this point is already fully connected to the host.
+ *
+ * The core must store the retro_netpacket_send_t function pointer provided
+ * here and use it whenever it wants to send a packet. This function pointer
+ * remains valid until the frontend calls retro_netpacket_stop_t.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_start_t)(uint16_t client_id, retro_netpacket_send_t send_fn);
+
+/* Called by the frontend when a new packet arrives which has been sent from
+ * another player with retro_netpacket_send_t. The client_id argument indicates
+ * who has sent the packet.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_receive_t)(const void* buf, size_t len, uint16_t client_id);
+
+/* Called by the frontend when the multiplayer session has ended.
+ * Once this gets called the retro_netpacket_send_t function pointer passed
+ * to retro_netpacket_start_t will not be valid anymore.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_stop_t)(void);
+
+/* Called by the frontend every frame (between calls to retro_run while
+ * updating the state of the multiplayer session.
+ * This is a good place for the core to call retro_netpacket_send_t from.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_poll_t)(void);
+
+/* Called by the frontend when a new player connects to the hosted session.
+ * This is only called on the host side, not for clients connected to the host.
+ * If this function returns false, the newly connected player gets dropped.
+ * This can be used for example to limit the number of players.
+ */
+typedef bool (RETRO_CALLCONV *retro_netpacket_connected_t)(uint16_t client_id);
+
+/* Called by the frontend when a player leaves or disconnects from the hosted session.
+ * This is only called on the host side, not for clients connected to the host.
+ */
+typedef void (RETRO_CALLCONV *retro_netpacket_disconnected_t)(uint16_t client_id);
+
+/**
+ * A callback interface for giving a core the ability to send and receive custom
+ * network packets during a multiplayer session between two or more instances
+ * of a libretro frontend.
+ *
+ * @see RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE
+ */
+struct retro_netpacket_callback
+{
+   retro_netpacket_start_t        start;
+   retro_netpacket_receive_t      receive;
+   retro_netpacket_stop_t         stop;         /* Optional - may be NULL */
+   retro_netpacket_poll_t         poll;         /* Optional - may be NULL */
+   retro_netpacket_connected_t    connected;    /* Optional - may be NULL */
+   retro_netpacket_disconnected_t disconnected; /* Optional - may be NULL */
+};
+
 enum retro_pixel_format
 {
    /* 0RGB1555, native endian.
@@ -2957,6 +3187,35 @@ enum retro_pixel_format
 
    /* Ensure sizeof() == sizeof(int). */
    RETRO_PIXEL_FORMAT_UNKNOWN  = INT_MAX
+};
+
+enum retro_savestate_context
+{
+   /* Standard savestate written to disk. */
+   RETRO_SAVESTATE_CONTEXT_NORMAL                 = 0,
+
+   /* Savestate where you are guaranteed that the same instance will load the save state.
+    * You can store internal pointers to code or data.
+    * It's still a full serialization and deserialization, and could be loaded or saved at any time. 
+    * It won't be written to disk or sent over the network.
+    */
+   RETRO_SAVESTATE_CONTEXT_RUNAHEAD_SAME_INSTANCE = 1,
+
+   /* Savestate where you are guaranteed that the same emulator binary will load that savestate.
+    * You can skip anything that would slow down saving or loading state but you can not store internal pointers. 
+    * It won't be written to disk or sent over the network.
+    * Example: "Second Instance" runahead
+    */
+   RETRO_SAVESTATE_CONTEXT_RUNAHEAD_SAME_BINARY   = 2,
+
+   /* Savestate used within a rollback netplay feature.
+    * You should skip anything that would unnecessarily increase bandwidth usage.
+    * It won't be written to disk but it will be sent over the network.
+    */
+   RETRO_SAVESTATE_CONTEXT_ROLLBACK_NETPLAY       = 3,
+
+   /* Ensure sizeof() == sizeof(int). */
+   RETRO_SAVESTATE_CONTEXT_UNKNOWN                = INT_MAX
 };
 
 struct retro_message
@@ -3430,6 +3689,10 @@ struct retro_core_option_definition
    const char *default_value;
 };
 
+#ifdef __PS3__
+#undef local
+#endif
+
 struct retro_core_options_intl
 {
    /* Pointer to an array of retro_core_option_definition structs
@@ -3665,6 +3928,326 @@ struct retro_fastforwarding_override
     * 'inhibit_toggle' is set to false, or the core
     * is unloaded */
    bool inhibit_toggle;
+};
+
+/* During normal operation. Rate will be equal to the core's internal FPS. */
+#define RETRO_THROTTLE_NONE              0
+
+/* While paused or stepping single frames. Rate will be 0. */
+#define RETRO_THROTTLE_FRAME_STEPPING    1
+
+/* During fast forwarding.
+ * Rate will be 0 if not specifically limited to a maximum speed. */
+#define RETRO_THROTTLE_FAST_FORWARD      2
+
+/* During slow motion. Rate will be less than the core's internal FPS. */
+#define RETRO_THROTTLE_SLOW_MOTION       3
+
+/* While rewinding recorded save states. Rate can vary depending on the rewind
+ * speed or be 0 if the frontend is not aiming for a specific rate. */
+#define RETRO_THROTTLE_REWINDING         4
+
+/* While vsync is active in the video driver and the target refresh rate is
+ * lower than the core's internal FPS. Rate is the target refresh rate. */
+#define RETRO_THROTTLE_VSYNC             5
+
+/* When the frontend does not throttle in any way. Rate will be 0.
+ * An example could be if no vsync or audio output is active. */
+#define RETRO_THROTTLE_UNBLOCKED         6
+
+struct retro_throttle_state
+{
+   /* The current throttling mode. Should be one of the values above. */
+   unsigned mode;
+
+   /* How many times per second the frontend aims to call retro_run.
+    * Depending on the mode, it can be 0 if there is no known fixed rate.
+    * This won't be accurate if the total processing time of the core and
+    * the frontend is longer than what is available for one frame. */
+   float rate;
+};
+
+/**
+ * Opaque handle to a microphone that's been opened for use.
+ * The underlying object is accessed or created with \c retro_microphone_interface_t.
+ */
+typedef struct retro_microphone retro_microphone_t;
+
+/**
+ * Parameters for configuring a microphone.
+ * Some of these might not be honored,
+ * depending on the available hardware and driver configuration.
+ */
+typedef struct retro_microphone_params
+{
+   /**
+    * The desired sample rate of the microphone's input, in Hz.
+    * The microphone's input will be resampled,
+    * so cores can ask for whichever frequency they need.
+    *
+    * If zero, some reasonable default will be provided by the frontend
+    * (usually from its config file).
+    *
+    * @see retro_get_mic_rate_t
+    */
+   unsigned rate;
+} retro_microphone_params_t;
+
+/**
+ * @copydoc retro_microphone_interface::open_mic
+ */
+typedef retro_microphone_t *(RETRO_CALLCONV *retro_open_mic_t)(const retro_microphone_params_t *params);
+
+/**
+ * @copydoc retro_microphone_interface::close_mic
+ */
+typedef void (RETRO_CALLCONV *retro_close_mic_t)(retro_microphone_t *microphone);
+
+/**
+ * @copydoc retro_microphone_interface::get_params
+ */
+typedef bool (RETRO_CALLCONV *retro_get_mic_params_t)(const retro_microphone_t *microphone, retro_microphone_params_t *params);
+
+/**
+ * @copydoc retro_microphone_interface::set_mic_state
+ */
+typedef bool (RETRO_CALLCONV *retro_set_mic_state_t)(retro_microphone_t *microphone, bool state);
+
+/**
+ * @copydoc retro_microphone_interface::get_mic_state
+ */
+typedef bool (RETRO_CALLCONV *retro_get_mic_state_t)(const retro_microphone_t *microphone);
+
+/**
+ * @copydoc retro_microphone_interface::read_mic
+ */
+typedef int (RETRO_CALLCONV *retro_read_mic_t)(retro_microphone_t *microphone, int16_t* samples, size_t num_samples);
+
+/**
+ * The current version of the microphone interface.
+ * Will be incremented whenever \c retro_microphone_interface or \c retro_microphone_params_t
+ * receive new fields.
+ *
+ * Frontends using cores built against older mic interface versions
+ * should not access fields introduced in newer versions.
+ */
+#define RETRO_MICROPHONE_INTERFACE_VERSION 1
+
+/**
+ * An interface for querying the microphone and accessing data read from it.
+ *
+ * @see RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE
+ */
+struct retro_microphone_interface
+{
+   /**
+    * The version of this microphone interface.
+    * Set by the core to request a particular version,
+    * and set by the frontend to indicate the returned version.
+    * 0 indicates that the interface is invalid or uninitialized.
+    */
+   unsigned interface_version;
+
+   /**
+    * Initializes a new microphone.
+    * Assuming that microphone support is enabled and provided by the frontend,
+    * cores may call this function whenever necessary.
+    * A microphone could be opened throughout a core's lifetime,
+    * or it could wait until a microphone is plugged in to the emulated device.
+    *
+    * The returned handle will be valid until it's freed,
+    * even if the audio driver is reinitialized.
+    *
+    * This function is not guaranteed to be thread-safe.
+    *
+    * @param args[in] Parameters used to create the microphone.
+    * May be \c NULL, in which case the default value of each parameter will be used.
+    *
+    * @returns Pointer to the newly-opened microphone,
+    * or \c NULL if one couldn't be opened.
+    * This likely means that no microphone is plugged in and recognized,
+    * or the maximum number of supported microphones has been reached.
+    *
+    * @note Microphones are \em inactive by default;
+    * to begin capturing audio, call \c set_mic_state.
+    * @see retro_microphone_params_t
+    */
+   retro_open_mic_t open_mic;
+
+   /**
+    * Closes a microphone that was initialized with \c open_mic.
+    * Calling this function will stop all microphone activity
+    * and free up the resources that it allocated.
+    * Afterwards, the handle is invalid and must not be used.
+    *
+    * A frontend may close opened microphones when unloading content,
+    * but this behavior is not guaranteed.
+    * Cores should close their microphones when exiting, just to be safe.
+    *
+    * @param microphone Pointer to the microphone that was allocated by \c open_mic.
+    * If \c NULL, this function does nothing.
+    *
+    * @note The handle might be reused if another microphone is opened later.
+    */
+   retro_close_mic_t close_mic;
+
+   /**
+    * Returns the configured parameters of this microphone.
+    * These may differ from what was requested depending on
+    * the driver and device configuration.
+    *
+    * Cores should check these values before they start fetching samples.
+    *
+    * Will not change after the mic was opened.
+    *
+    * @param microphone[in] Opaque handle to the microphone
+    * whose parameters will be retrieved.
+    * @param params[out] The parameters object that the
+    * microphone's parameters will be copied to.
+    *
+    * @return \c true if the parameters were retrieved,
+    * \c false if there was an error.
+    */
+   retro_get_mic_params_t get_params;
+
+   /**
+    * Enables or disables the given microphone.
+    * Microphones are disabled by default
+    * and must be explicitly enabled before they can be used.
+    * Disabled microphones will not process incoming audio samples,
+    * and will therefore have minimal impact on overall performance.
+    * Cores may enable microphones throughout their lifetime,
+    * or only for periods where they're needed.
+    *
+    * Cores that accept microphone input should be able to operate without it;
+    * we suggest substituting silence in this case.
+    *
+    * @param microphone Opaque handle to the microphone
+    * whose state will be adjusted.
+    * This will have been provided by \c open_mic.
+    * @param state \c true if the microphone should receive audio input,
+    * \c false if it should be idle.
+    * @returns \c true if the microphone's state was successfully set,
+    * \c false if \c microphone is invalid
+    * or if there was an error.
+    */
+   retro_set_mic_state_t set_mic_state;
+
+   /**
+    * Queries the active state of a microphone at the given index.
+    * Will return whether the microphone is enabled,
+    * even if the driver is paused.
+    *
+    * @param microphone Opaque handle to the microphone
+    * whose state will be queried.
+    * @return \c true if the provided \c microphone is valid and active,
+    * \c false if not or if there was an error.
+    */
+   retro_get_mic_state_t get_mic_state;
+
+   /**
+    * Retrieves the input processed by the microphone since the last call.
+    * \em Must be called every frame unless \c microphone is disabled,
+    * similar to how \c retro_audio_sample_batch_t works.
+    *
+    * @param[in] microphone Opaque handle to the microphone
+    * whose recent input will be retrieved.
+    * @param[out] samples The buffer that will be used to store the microphone's data.
+    * Microphone input is in mono (i.e. one number per sample).
+    * Should be large enough to accommodate the expected number of samples per frame;
+    * for example, a 44.1kHz sample rate at 60 FPS would require space for 735 samples.
+    * @param[in] num_samples The size of the data buffer in samples (\em not bytes).
+    * Microphone input is in mono, so a "frame" and a "sample" are equivalent in length here.
+    *
+    * @return The number of samples that were copied into \c samples.
+    * If \c microphone is pending driver initialization,
+    * this function will copy silence of the requested length into \c samples.
+    *
+    * Will return -1 if the microphone is disabled,
+    * the audio driver is paused,
+    * or there was an error.
+    */
+   retro_read_mic_t read_mic;
+};
+
+/**
+ * Describes how a device is being powered.
+ * @see RETRO_ENVIRONMENT_GET_DEVICE_POWER
+ */
+enum retro_power_state
+{
+   /**
+    * Indicates that the frontend cannot report its power state at this time,
+    * most likely due to a lack of support.
+    *
+    * \c RETRO_ENVIRONMENT_GET_DEVICE_POWER will not return this value;
+    * instead, the environment callback will return \c false.
+    */
+   RETRO_POWERSTATE_UNKNOWN = 0,
+
+   /**
+    * Indicates that the device is running on its battery.
+    * Usually applies to portable devices such as handhelds, laptops, and smartphones.
+    */
+   RETRO_POWERSTATE_DISCHARGING,
+
+   /**
+    * Indicates that the device's battery is currently charging.
+    */
+   RETRO_POWERSTATE_CHARGING,
+
+   /**
+    * Indicates that the device is connected to a power source
+    * and that its battery has finished charging.
+    */
+   RETRO_POWERSTATE_CHARGED,
+
+   /**
+    * Indicates that the device is connected to a power source
+    * and that it does not have a battery.
+    * This usually suggests a desktop computer or a non-portable game console.
+    */
+   RETRO_POWERSTATE_PLUGGED_IN
+};
+
+/**
+ * Indicates that an estimate is not available for the battery level or time remaining,
+ * even if the actual power state is known.
+ */
+#define RETRO_POWERSTATE_NO_ESTIMATE (-1)
+
+/**
+ * Describes the power state of the device running the frontend.
+ * @see RETRO_ENVIRONMENT_GET_DEVICE_POWER
+ */
+struct retro_device_power
+{
+   /**
+    * The current state of the frontend's power usage.
+    */
+   enum retro_power_state state;
+
+   /**
+    * A rough estimate of the amount of time remaining (in seconds)
+    * before the device powers off.
+    * This value depends on a variety of factors,
+    * so it is not guaranteed to be accurate.
+    *
+    * Will be set to \c RETRO_POWERSTATE_NO_ESTIMATE if \c state does not equal \c RETRO_POWERSTATE_DISCHARGING.
+    * May still be set to \c RETRO_POWERSTATE_NO_ESTIMATE if the frontend is unable to provide an estimate.
+    */
+   int seconds;
+
+   /**
+    * The approximate percentage of battery charge,
+    * ranging from 0 to 100 (inclusive).
+    * The device may power off before this reaches 0.
+    *
+    * The user might have configured their device
+    * to stop charging before the battery is full,
+    * so do not assume that this will be 100 in the \c RETRO_POWERSTATE_CHARGED state.
+    */
+   int8_t percent;
 };
 
 /* Callbacks */


### PR DESCRIPTION
Seems functional, but a little more sensitive than the RetroArch implementation. I didn't see anything in the SDL documentation for tweaking the sensitivity.