### PR TITLE
RAHasher: hash multiple files via wildcards

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1354,7 +1354,7 @@ bool Application::unloadGame()
 
   if (_gamePathIsTemporary)
   {
-    _logger.debug(TAG "Deleting temporary content %s", _gamePath);
+    _logger.debug(TAG "Deleting temporary content %s", _gamePath.c_str());
     util::deleteFile(_gamePath);
     _gamePathIsTemporary = false;
   }


### PR DESCRIPTION
Verbose mode and system detection are not supported when hashing multiple files.

```
E:\Source\RetroAchievements\RALibretro>bin64\RAHasher.exe 72 E:\Games\RetroAchievements\ROMs\Other\WASM\*
f4d55cbcb51b2c11010b7999fd913cec antcopter.wasm
f4d55cbcb51b2c11010b7999fd913cec antcopter.zip
04afe658b3c9e2e61dbef7897d604adc miku-15.wasm
7e372d919d84e94f14c71222f1f372f2 the-legend-of-geml-awakening.wasm
06c02089c236dff8af5ca6fe42c9eab6 to-the-core.wasm
04d126cfe702b2d2114b190c11536302 wormhole.wasm
```

```
$ bin64/RAHasher 7 ~/roms/*.nes
25cf03eb7ac2dec4ef332425c151f373 Dragon Warrior (U).nes
811b027eaf99c2def7b933c5208636de Super Mario Bros. (W) [!].nes
```