### PR TITLE
enable GB/GBC for mGBA core

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -458,14 +458,12 @@
   "mgba_libretro":{
     "name": "mGBA",
     "extensions": "gb",
-    "systems": [4],
-    "platforms": "none"
+    "systems": [4]
   },
   "mgba_libretro":{
     "name": "mGBA",
     "extensions": "gbc",
-    "systems": [6],
-    "platforms": "none"
+    "systems": [6]
   },
   "mgba_libretro":{
     "name": "mGBA",


### PR DESCRIPTION
camera interface issue was resolved (a couple years ago)