### PR TITLE
make vfs_seek behave like fseek

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -594,8 +594,7 @@
   },
   "quasi88_libretro":{
     "name": "QUASI88",
-    "systems": [47],
-    "platforms": "none"
+    "systems": [47]
   },
   "quicknes_libretro":{
     "name": "QuickNES",

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -974,8 +974,7 @@ static int64_t retro_vfs_file_seek_impl(retro_vfs_file_handle* stream, int64_t o
       break;
   }
 
-  _fseeki64(stream->fp, offset, whence);
-  return retro_vfs_file_tell_impl(stream);
+  return _fseeki64(stream->fp, offset, whence);
 }
 
 static int64_t retro_vfs_file_size_impl(retro_vfs_file_handle* stream)


### PR DESCRIPTION
The [header file](https://github.com/libretro/RetroArch/blob/a3f13b226874121422c8f967d69950809b8670ff/libretro-common/include/libretro.h#L2800-L2812) says that retro_vfs_seek_t should return the new position, or -1 on error (this is true prior to the [recent doc expansion](https://github.com/libretro/RetroArch/blob/a417f744766347d8bd8e2ff1e8169479ec0af22e/libretro-common/include/libretro.h#L1943-L1945) as well).

But the implementation (at least for unbuffered files [calls fseek](https://github.com/libretro/RetroArch/blob/master/libretro-common/vfs/vfs_implementation.c#L224-L245)), which returns 0 on success, not the offset.

The quasi88 core is treating [any non-zero return value as a failure](https://github.com/libretro/quasi88-libretro/blob/ff94d9d2884d71580c163fcd71b6850c0f393f44/src/fdc.c#L474-L478), so because I was explicitly returning the new offset, the core would refuse to start games.

I've [asked the libretro](https://discord.com/channels/184109094070779904/434759979095031840/1277130480554344578) team for clarification on this behavior, without an response. Since this mimics the RetroArch behavior, I think it's correct.