### PR TITLE
Allow RAHasher be compiled for arm64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,8 @@
 
 include Makefile.common
 
-ifeq ($(ARCH), x86)
-  CFLAGS += -m32
-  CXXFLAGS += -m32
-  LDFLAGS += -m32
-  OUTDIR=bin
-else ifeq ($(ARCH), x64)
-  CFLAGS += -m64
-  CXXFLAGS += -m64
-  LDFLAGS += -m64
-  OUTDIR=bin64
-else
-  $(error unknown ARCH "$(ARCH)")
+ifeq ($(ARCH), arm64)
+  $(error Cannot build for arm64)
 endif
 
 # Toolset setup

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,20 @@
 
 include Makefile.common
 
+ifeq ($(ARCH), x86)
+  CFLAGS += -m32
+  CXXFLAGS += -m32
+  LDFLAGS += -m32
+  OUTDIR=bin
+else ifeq ($(ARCH), x64)
+  CFLAGS += -m64
+  CXXFLAGS += -m64
+  LDFLAGS += -m64
+  OUTDIR=bin64
+else
+  $(error unknown ARCH "$(ARCH)")
+endif
+
 # Toolset setup
 ifeq ($(OS),Windows_NT)
   CC=gcc

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -8,25 +8,6 @@ include Makefile.common
 CC=gcc
 CXX=g++
 
-ifeq ($(ARCH), x86)
-  CFLAGS += -m32
-  CXXFLAGS += -m32
-  LDFLAGS += -m32
-  OUTDIR=bin
-else ifeq ($(ARCH), x64)
-  CFLAGS += -m64
-  CXXFLAGS += -m64
-  LDFLAGS += -m64
-  OUTDIR=bin64
-else ifeq ($(ARCH), arm64)
-  CFLAGS += -march=armv8-a
-  CXXFLAGS += -march=armv8-a
-  LDFLAGS += -march=armv8-a
-  OUTDIR=bin64
-else
-  $(error unknown ARCH "$(ARCH)")
-endif
-
 ifeq ($(OS),Windows_NT)
   EXE=.exe
   KERNEL=windows

--- a/Makefile.RAHasher
+++ b/Makefile.RAHasher
@@ -8,6 +8,25 @@ include Makefile.common
 CC=gcc
 CXX=g++
 
+ifeq ($(ARCH), x86)
+  CFLAGS += -m32
+  CXXFLAGS += -m32
+  LDFLAGS += -m32
+  OUTDIR=bin
+else ifeq ($(ARCH), x64)
+  CFLAGS += -m64
+  CXXFLAGS += -m64
+  LDFLAGS += -m64
+  OUTDIR=bin64
+else ifeq ($(ARCH), arm64)
+  CFLAGS += -march=armv8-a
+  CXXFLAGS += -march=armv8-a
+  LDFLAGS += -march=armv8-a
+  OUTDIR=bin64
+else
+  $(error unknown ARCH "$(ARCH)")
+endif
+
 ifeq ($(OS),Windows_NT)
   EXE=.exe
   KERNEL=windows

--- a/Makefile.common
+++ b/Makefile.common
@@ -9,6 +9,8 @@ ifeq ($(ARCH),)
     UNAME := $(shell uname -m)
     ifeq ($(UNAME), x86_64)
       ARCH=x64
+    else ifeq ($(UNAME), aarch64)
+      ARCH=arm64
     else
       ARCH=x86
     endif
@@ -19,20 +21,6 @@ INCLUDES=-Isrc -I./src/miniz -I./src/rcheevos/include
 CFLAGS=-Wall $(INCLUDES)
 CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-static-libgcc -static-libstdc++
-
-ifeq ($(ARCH), x86)
-  CFLAGS += -m32
-  CXXFLAGS += -m32
-  LDFLAGS += -m32
-  OUTDIR=bin
-else ifeq ($(ARCH), x64)
-  CFLAGS += -m64
-  CXXFLAGS += -m64
-  LDFLAGS += -m64
-  OUTDIR=bin64
-else
-  $(error unknown ARCH "$(ARCH)")
-endif
 
 ifneq ($(DEBUG),)
   CFLAGS   += -O0 -g

--- a/Makefile.common
+++ b/Makefile.common
@@ -22,6 +22,25 @@ CFLAGS=-Wall $(INCLUDES)
 CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-static-libgcc -static-libstdc++
 
+ifeq ($(ARCH), x86)
+  CFLAGS += -m32
+  CXXFLAGS += -m32
+  LDFLAGS += -m32
+  OUTDIR=bin
+else ifeq ($(ARCH), x64)
+  CFLAGS += -m64
+  CXXFLAGS += -m64
+  LDFLAGS += -m64
+  OUTDIR=bin64
+else ifeq ($(ARCH), arm64)
+  CFLAGS += -march=armv8-a
+  CXXFLAGS += -march=armv8-a
+  LDFLAGS += -march=armv8-a
+  OUTDIR=bin64
+else
+  $(error unknown ARCH "$(ARCH)")
+endif
+
 ifneq ($(DEBUG),)
   CFLAGS   += -O0 -g
   CXXFLAGS += -O0 -g


### PR DESCRIPTION
The included changes to `Makefile`s were the only required ones to make the build process work on `arm64`.

As `-march=armv8-a` was invalid when trying to build RALibretro, I have only added ARM64 support for `RAHasher`.

Building process can be tested using the following Dockerfile:

```dockerfile
FROM debian:12

RUN apt-get update && apt-get install -y --no-install-recommends \
        build-essential \
        zlib1g-dev

WORKDIR /src
COPY . .

RUN make HAVE_CHD=1 -f ./Makefile.RAHasher
```

Using the following command:

```shell
docker buildx build -t rahasher:arm --platform linux/arm64 .
```