### PR TITLE
Add indicator for pause/fast forward

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -581,7 +581,17 @@ void Application::run()
         case Fsm::State::GamePausedNoOvl:
         default:
           // do no frames
-          Sleep(10);
+          Sleep(1000 / 60); // assume 60fps
+
+          // if a message is on-screen, force repaint to advance the message animation
+          if (_video.hasMessage())
+          {
+            _video.draw(true);
+
+            // no more on-screen messages, force repaint to clear the popups
+            if (!_video.hasMessage())
+              _video.draw(true);
+          }
           break;
 
         case Fsm::State::FrameStep:

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -586,11 +586,11 @@ void Application::run()
           // if a message is on-screen, force repaint to advance the message animation
           if (_video.hasMessage())
           {
-            _video.draw(true);
+            _video.redraw();
 
             // no more on-screen messages, force repaint to clear the popups
             if (!_video.hasMessage())
-              _video.draw(true);
+              _video.redraw();
           }
           break;
 
@@ -2346,7 +2346,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
     case IDM_EMULATOR_CONFIG:
       _config.showEmulatorSettingsDialog();
       updateSpeedIndicator();
-      _video.draw(true);
+      _video.redraw();
       break;
 
     case IDM_SAVING_CONFIG:
@@ -2669,7 +2669,7 @@ void Application::updateSpeedIndicator()
   case Fsm::State::GamePausedNoOvl:
   case Fsm::State::FrameStep:
     _video.showSpeedIndicator(Video::Speed::Paused);
-    _video.draw(true);
+    _video.redraw();
     break;
 
   default:

--- a/src/Application.h
+++ b/src/Application.h
@@ -125,6 +125,7 @@ protected:
   void        loadConfiguration(int* window_x, int* window_y, int* window_width, int* window_height);
   void        saveConfiguration();
   std::string serializeRecentList();
+  void        updateSpeedIndicator();
   void        toggleFastForwarding(unsigned extra);
   void        toggleBackgroundInput();
   void        setBackgroundInput(bool enabled);

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -93,6 +93,8 @@ bool Config::init(libretro::LoggerComponent* logger)
   // these settings are global and should not be modified by reset()
   _audioWhileFastForwarding = true;
   _fastForwardRatio = 5;
+  _backgroundInput = false;
+  _showSpeedIndicator = true;
 
   reset();
   return true;
@@ -550,7 +552,7 @@ void Config::initializeControllerVariable(Variable& variable, const char* name, 
   }
 }
 
-std::string Config::serializeEmulatorSettings()
+std::string Config::serializeEmulatorSettings() const
 {
   std::string json("{");
 
@@ -564,6 +566,10 @@ std::string Config::serializeEmulatorSettings()
 
   json.append("\"backgroundInput\":");
   json.append(_backgroundInput ? "true" : "false");
+  json.append(",");
+
+  json.append("\"showSpeedIndicator\":");
+  json.append(_showSpeedIndicator ? "true" : "false");
 
   json.append("}");
   return json;
@@ -597,6 +603,10 @@ bool Config::deserializeEmulatorSettings(const char* json)
       else if (ud->key == "backgroundInput")
       {
         ud->self->_backgroundInput = num != 0;
+      }
+      else if (ud->key == "showSpeedIndicator")
+      {
+        ud->self->_showSpeedIndicator = num != 0;
       }
     }
     else if (event == JSONSAX_NUMBER)
@@ -908,7 +918,7 @@ static const char* s_getFastForwardRatioOptions(int index, void* udata)
 
 void Config::showEmulatorSettingsDialog()
 {
-  const WORD WIDTH = 140;
+  const WORD WIDTH = 170;
   const WORD LINE = 15;
 
   Dialog db;
@@ -925,6 +935,10 @@ void Config::showEmulatorSettingsDialog()
   db.addCheckbox("Play Audio while Fast Forwarding", 51002, 0, y, WIDTH - 10, 8, &playAudio);
   y += LINE;
 
+  bool showSpeedIndicator = _showSpeedIndicator;
+  db.addCheckbox("Show Indicator when Paused or Fast Forwarding", 51004, 0, y, WIDTH - 10, 8, &showSpeedIndicator);
+  y += LINE;
+
   db.addButton("OK", IDOK, WIDTH - 55 - 50, y, 50, 14, true);
   db.addButton("Cancel", IDCANCEL, WIDTH - 50, y, 50, 14, false);
 
@@ -932,6 +946,7 @@ void Config::showEmulatorSettingsDialog()
   {
     _audioWhileFastForwarding = playAudio;
     _fastForwardRatio = fastForwardRatio + 2;
+    _showSpeedIndicator = showSpeedIndicator;
   }
 }
 #endif

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -57,6 +57,9 @@ public:
   virtual bool getAudioWhileFastForwarding() override { return _audioWhileFastForwarding; }
   virtual int getFastForwardRatio() override { return _fastForwardRatio; }
 
+  virtual bool getShowSpeedIndicator() override { return _showSpeedIndicator; }
+  virtual void setShowSpeedIndicator(bool value) override { _showSpeedIndicator = value; }
+
   void setSaveDirectory(const std::string& path) { _saveFolder = path; }
 
   const char* getRootFolder()
@@ -74,7 +77,7 @@ public:
 
   bool validateSettingsForHardcore(const char* library_name, int console_id, bool prompt);
 
-  std::string serializeEmulatorSettings();
+  std::string serializeEmulatorSettings() const;
   bool deserializeEmulatorSettings(const char* json);
 
 #ifdef _WINDOWS
@@ -148,6 +151,7 @@ protected:
   bool _hadDisallowedSetting;
   bool _audioWhileFastForwarding;
   bool _backgroundInput;
+  bool _showSpeedIndicator;
 
   int _fastForwardRatio;
 

--- a/src/components/Video.cpp
+++ b/src/components/Video.cpp
@@ -189,6 +189,13 @@ void Video::clear()
   _ctx->swapBuffers();
 }
 
+void Video::redraw()
+{
+  _ctx->enableCoreContext(false);
+  draw(true);
+  _ctx->enableCoreContext(true);
+}
+
 void Video::draw(bool force)
 {
   if (_texture != 0 && (force || _enabled))
@@ -469,6 +476,8 @@ void Video::showMessage(const char* msg, unsigned frames)
     Gl::pixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     Gl::bindTexture(GL_TEXTURE_2D, 0);
   }
+
+  _ctx->enableCoreContext(true);
 
   free(data);
 }

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -47,6 +47,7 @@ public:
   virtual retro_proc_address_t getProcAddress(const char* symbol) override;
 
   virtual void showMessage(const char* msg, unsigned frames) override;
+  bool hasMessage() const { return _numMessages != 0; }
 
   void windowResized(unsigned width, unsigned height);
   void getFramebufferSize(unsigned* width, unsigned* height, enum retro_pixel_format* format);

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -36,7 +36,7 @@ public:
   virtual void setEnabled(bool enabled) override;
 
   void clear();
-  void draw(bool force = false);
+  void redraw();
 
   virtual bool setGeometry(unsigned width, unsigned height, unsigned maxWidth, unsigned maxHeight, float aspect, enum retro_pixel_format pixelFormat, const struct retro_hw_render_callback* hwRenderCallback) override;
   virtual void refresh(const void* data, unsigned width, unsigned height, size_t pitch) override;
@@ -76,6 +76,8 @@ public:
   void setRotationChangedHandler(RotationHandler handler) { _rotationHandler = handler; }
 
 protected:
+  void draw(bool force = false);
+
   GLuint createProgram(GLint* pos, GLint* uv, GLint* tex);
   bool ensureVertexArray(unsigned windowWidth, unsigned windowHeight, float texScaleX, float texScaleY, GLint pos, GLint uv);
   GLuint createTexture(unsigned width, unsigned height, retro_pixel_format pixelFormat, bool linear);

--- a/src/components/Video.h
+++ b/src/components/Video.h
@@ -49,6 +49,8 @@ public:
   virtual void showMessage(const char* msg, unsigned frames) override;
   bool hasMessage() const { return _numMessages != 0; }
 
+  virtual void showSpeedIndicator(Speed visibleIndicator) override;
+
   void windowResized(unsigned width, unsigned height);
   void getFramebufferSize(unsigned* width, unsigned* height, enum retro_pixel_format* format);
   const void* getFramebuffer(unsigned* width, unsigned* height, unsigned* pitch, enum retro_pixel_format* format);
@@ -100,6 +102,7 @@ protected:
   unsigned                _messageWidth[4];
   unsigned                _messageFrames[4];
   unsigned                _numMessages;
+  GLuint                  _speedIndicatorTexture;
 
   unsigned                _windowWidth;
   unsigned                _windowHeight;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -156,6 +156,9 @@ namespace libretro
 
     virtual bool getAudioWhileFastForwarding() = 0;
     virtual int getFastForwardRatio() = 0;
+
+    virtual bool getShowSpeedIndicator() = 0;
+    virtual void setShowSpeedIndicator(bool value) = 0;
   };
 
   /**
@@ -186,6 +189,14 @@ namespace libretro
     virtual retro_proc_address_t getProcAddress(const char* symbol) = 0;
 
     virtual void showMessage(const char* msg, unsigned frames) = 0;
+
+    enum class Speed
+    {
+      None,
+      Paused,
+      FastForwarding,
+    };
+    virtual void showSpeedIndicator(Speed visibleIndicator) = 0;
 
     /* NOTE: these are counter-clockwise rotations per libretro.h */
     enum class Rotation

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -154,6 +154,16 @@ namespace
     {
       return 5;
     }
+
+    virtual bool getShowSpeedIndicator() override
+    {
+      return false;
+    }
+
+    virtual void setShowSpeedIndicator(bool value) override
+    {
+      (void)value;
+    }
   };
 
   class DummyVideoContext : public libretro::VideoContextComponent
@@ -222,6 +232,11 @@ namespace
     {
       (void)msg;
       (void)frames;
+    }
+
+    virtual void showSpeedIndicator(Speed visibleIndicator) override
+    {
+      (void)visibleIndicator;
     }
 
     virtual void setRotation(Rotation rotation) override


### PR DESCRIPTION
Adds an indicator in the upper right corner of the screen when the emulator is paused or in turbo mode.
![image](https://github.com/user-attachments/assets/0fa187f5-4a25-4785-af8b-0c985920dd29)
![image](https://github.com/user-attachments/assets/c445dcfb-b43d-43d3-b182-c11bdcefa032)

If undesirable, this can be disabled in the Emulator Settings dialog:
![image](https://github.com/user-attachments/assets/55e1c693-21fb-48a0-8611-fca136fe67a7)


