### PR TITLE
add hotkeys for changing disks

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1656,6 +1656,62 @@ void Application::enableRecent()
   }
 }
 
+void Application::toggleTray()
+{
+  if (_core.getNumDiscs() > 0)
+  {
+    _core.setTrayOpen(!_core.getTrayOpen());
+    updateDiscMenu(false);
+
+    if (_core.getTrayOpen())
+    {
+      _video.showMessage(_isDriveFloppy ? "Floppy ejected" : "Disc ejected", 200);
+    }
+    else
+    {
+      std::string message = "Inserted " + getDiscLabel(_core.getCurrentDiscIndex());
+      _video.showMessage(message.c_str(), 200);
+    }
+  }
+}
+
+void Application::readyNextDisc(int offset)
+{
+  const unsigned numDiscs = _core.getNumDiscs();
+  if (numDiscs > 0)
+  {
+    if (_core.getTrayOpen())
+      readyDisc((_core.getCurrentDiscIndex() + numDiscs + offset) % numDiscs);
+    else
+      _video.showMessage(_isDriveFloppy ? "Cannot change floppy until previous floppy ejected" : "Cannot change disc until previous disc ejected", 200);
+  }
+}
+
+void Application::readyDisc(unsigned newDiscIndex)
+{
+  if (_core.getCurrentDiscIndex() != newDiscIndex)
+  {
+    std::string path;
+    if (_core.getDiscPath(newDiscIndex, path))
+    {
+      if (!romLoaded(&_core, &_logger, _system, path, NULL, 0, true))
+        return;
+    }
+    else if (newDiscIndex < _discPaths.size())
+    {
+      path = util::replaceFileName(_gamePath, _discPaths.at(newDiscIndex).c_str());
+      if (!romLoaded(&_core, &_logger, _system, path, NULL, 0, true))
+        return;
+    }
+
+    _core.setCurrentDiscIndex(newDiscIndex);
+    updateDiscMenu(false);
+
+    std::string message = "Readied " + getDiscLabel(newDiscIndex);
+    _video.showMessage(message.c_str(), 200);
+  }
+}
+
 void Application::updateDiscMenu(bool updateLabels)
 {
   size_t i = 0;
@@ -1706,27 +1762,8 @@ void Application::updateDiscMenu(bool updateLabels)
 
       if (updateLabels)
       {
-        if (_core.getDiscLabel(i, discLabel))
-        {
-          info.dwTypeData = (char*)discLabel.data();
-        }
-        else if (i < _discPaths.size())
-        {
-          const std::string& path = _discPaths.at(i);
-          size_t index = path.find_last_of('\\');
-          if (index == std::string::npos)
-            index = path.find_last_of('/');
-
-          if (index != std::string::npos)
-            info.dwTypeData = (LPSTR)&path.at(index + 1);
-          else
-            info.dwTypeData = (LPSTR)&path.at(0);
-        }
-        else
-        {
-          sprintf(buffer, "Disc %d", (int)(i + 1));
-          info.dwTypeData = buffer;
-        }
+        discLabel = getDiscLabel(i);
+        info.dwTypeData = (char*)discLabel.data();
       }
 
       info.fState = (i == selectedDisc) ? MFS_CHECKED : MFS_UNCHECKED;
@@ -1738,6 +1775,33 @@ void Application::updateDiscMenu(bool updateLabels)
 
     EnableMenuItem(_menu, IDM_CD_OPEN_TRAY, MF_ENABLED);
   }
+}
+
+std::string Application::getDiscLabel(unsigned index) const
+{
+  std::string discLabel;
+
+  if (_core.getDiscLabel(index, discLabel))
+    return discLabel;
+
+  if (index < _discPaths.size())
+  {
+    const std::string& path = _discPaths.at(index);
+    size_t lastSlashIndex = path.find_last_of('\\');
+    if (lastSlashIndex == std::string::npos)
+      lastSlashIndex = path.find_last_of('/');
+
+    if (lastSlashIndex != std::string::npos)
+      discLabel = path.substr(lastSlashIndex + 1);
+    else
+      discLabel = path;
+  }
+  else
+  {
+    discLabel = "Disc " + index;
+  }
+
+  return discLabel;
 }
 
 std::string Application::getStatePath(unsigned ndx)
@@ -2263,8 +2327,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
     }
     
     case IDM_CD_OPEN_TRAY:
-      _core.setTrayOpen(!_core.getTrayOpen());
-      updateDiscMenu(false);
+      toggleTray();
       break;
 
     case IDM_PAUSE_GAME:
@@ -2382,24 +2445,7 @@ void Application::handle(const SDL_SysWMEvent* syswm)
       else if (cmd >= IDM_CD_DISC_FIRST && cmd <= IDM_CD_DISC_LAST)
       {
         unsigned newDiscIndex = cmd - IDM_CD_DISC_FIRST;
-        if (_core.getCurrentDiscIndex() != newDiscIndex)
-        {
-          std::string path;
-          if (_core.getDiscPath(newDiscIndex, path))
-          {
-            if (!romLoaded(&_core, &_logger, _system, path, NULL, 0, true))
-              break;
-          }
-          else if (newDiscIndex < _discPaths.size())
-          {
-            path = util::replaceFileName(_gamePath, _discPaths.at(newDiscIndex).c_str());
-            if (!romLoaded(&_core, &_logger, _system, path, NULL, 0, true))
-              break;
-          }
-
-          _core.setCurrentDiscIndex(newDiscIndex);
-          updateDiscMenu(false);
-        }
+        readyDisc(newDiscIndex);
       }
       else if (cmd >= IDM_SYSTEM_FIRST && cmd <= IDM_SYSTEM_LAST)
       {
@@ -2550,6 +2596,11 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
   case KeyBinds::Action::kLoadState:        loadState(extra); break;
   case KeyBinds::Action::kChangeCurrentState: changeCurrentState(extra); break;
 
+  // Disc management
+  case KeyBinds::Action::kToggleTray:       toggleTray(); break;
+  case KeyBinds::Action::kReadyNextDisc:    readyNextDisc(1); break;
+  case KeyBinds::Action::kReadyPreviousDisc:readyNextDisc(-1); break;
+
   // Window size
   case KeyBinds::Action::kSetWindowSize1:   resizeWindow(1); break;
   case KeyBinds::Action::kSetWindowSize2:   resizeWindow(2); break;
@@ -2621,6 +2672,7 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
     updateMenu();
 
     _video.showMessage(_keybinds.hasGameFocus() ? "Game focus enabled" : "Game focus disabled", 60);
+    SDL_SetRelativeMouseMode(_keybinds.hasGameFocus() ? SDL_TRUE : SDL_FALSE);
     break;
   }
 }

--- a/src/Application.h
+++ b/src/Application.h
@@ -129,6 +129,10 @@ protected:
   void        toggleFastForwarding(unsigned extra);
   void        toggleBackgroundInput();
   void        setBackgroundInput(bool enabled);
+  void        toggleTray();
+  void        readyNextDisc(int offset);
+  void        readyDisc(unsigned newDiscIndex);
+  std::string getDiscLabel(unsigned index) const;
 
   Fsm _fsm;
   bool lastHardcore;

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -120,6 +120,11 @@ enum
   kLoadCurrent,
   kSaveCurrent,
 
+  // Disc management
+  kToggleTray,
+  kReadyNextDisc,
+  kReadyPreviousDisc,
+
   // Window size
   kSetWindowSize1,
   kSetWindowSize2,
@@ -165,6 +170,8 @@ static const char* bindingNames[] = {
   "NEXT_SLOT", "PREV_SLOT",
   "SLOT1", "SLOT2", "SLOT3", "SLOT4", "SLOT5", "SLOT6", "SLOT7", "SLOT8", "SLOT9", "SLOT0",
   "LOAD_SLOT", "SAVE_SLOT",
+
+  "TRAY_OPEN", "DISK_NEXT", "DISK_PREV",
 
   "WINDOW_1X", "WINDOW_2X", "WINDOW_3X", "WINDOW_4X", "WINDOW_5X",
   "TOGGLE_FULLSCREEN", "ROTATE_RIGHT", "ROTATE_LEFT",
@@ -286,6 +293,9 @@ bool KeyBinds::init(Logger* logger)
   _bindings[kToggleFullscreen] = { 0, SDLK_RETURN, Binding::Type::Key, KMOD_ALT };
   _bindings[kRotateRight] = { 0, SDLK_r, Binding::Type::Key, KMOD_CTRL };
   _bindings[kRotateLeft] = { 0, SDLK_r, Binding::Type::Key, KMOD_CTRL | KMOD_SHIFT };
+  _bindings[kToggleTray] = { 0, SDLK_MINUS, Binding::Type::Key, KMOD_ALT };
+  _bindings[kReadyNextDisc] = { 0, SDLK_EQUALS, Binding::Type::Key, KMOD_ALT };
+  _bindings[kReadyPreviousDisc] = { 0, SDLK_0, Binding::Type::Key, KMOD_ALT };
 
   _bindings[kPauseToggle] = { 0, SDLK_ESCAPE, Binding::Type::Key, 0 };
   _bindings[kPauseToggleNoOvl] = { 0, SDLK_p, Binding::Type::Key, 0 };
@@ -421,6 +431,11 @@ KeyBinds::Action KeyBinds::translateButtonPress(int button, unsigned* extra)
     case kSetSlot10:    *extra = _slot = 10; return Action::kChangeCurrentState;
     case kLoadCurrent:  *extra = _slot; return Action::kLoadState;
     case kSaveCurrent:  *extra = _slot; return Action::kSaveState;
+
+    // Disc management
+    case kToggleTray:        return Action::kToggleTray;
+    case kReadyNextDisc:     return Action::kReadyNextDisc;
+    case kReadyPreviousDisc: return Action::kReadyPreviousDisc;
 
     // Window size
     case kSetWindowSize1:    return Action::kSetWindowSize1;
@@ -1494,6 +1509,9 @@ public:
     addButtonInput(4, 0, "Frame Advance", kStep);
     addButtonInput(5, 0, "Fast Forward (Hold)", kFastForward);
     addButtonInput(6, 0, "Fast Forward (Toggle)", kFastForwardToggle);
+    addButtonInput(7, 0, "Insert/Eject Disc", kToggleTray);
+    addButtonInput(8, 0, "Ready Next Disc", kReadyNextDisc);
+    addButtonInput(9, 0, "Ready Previous Disc", kReadyPreviousDisc);
 
     addButtonInput(0, 2, "Window Size 1x", kSetWindowSize1);
     addButtonInput(1, 2, "Window Size 2x", kSetWindowSize2);

--- a/src/KeyBinds.h
+++ b/src/KeyBinds.h
@@ -64,6 +64,11 @@ public:
     kLoadState,
     kChangeCurrentState,
 
+    // Disc management
+    kToggleTray,
+    kReadyNextDisc,
+    kReadyPreviousDisc,
+
     // Window size
     kSetWindowSize1,
     kSetWindowSize2,
@@ -120,7 +125,7 @@ public:
     Type type;
     uint16_t modifiers;
   };
-  typedef std::array<Binding, 98> BindingList;
+  typedef std::array<Binding, 101> BindingList;
 
   static void getBindingString(char buffer[32], const KeyBinds::Binding& desc);
 

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -862,7 +862,7 @@ bool libretro::Core::setDiskControlExtInterface(const struct retro_disk_control_
   return true;
 }
 
-bool libretro::Core::getDiscLabel(unsigned index, std::string& label)
+bool libretro::Core::getDiscLabel(unsigned index, std::string& label) const
 {
   if (_diskControlInterface.get_image_label)
   {
@@ -877,7 +877,7 @@ bool libretro::Core::getDiscLabel(unsigned index, std::string& label)
   return false;
 }
 
-bool libretro::Core::getDiscPath(unsigned index, std::string& path)
+bool libretro::Core::getDiscPath(unsigned index, std::string& path) const
 {
   if (_diskControlInterface.get_image_path)
   {

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -69,8 +69,8 @@ namespace libretro
     inline unsigned                getNumDiscs()            const { return (_diskControlInterface.get_num_images != NULL) ? _diskControlInterface.get_num_images() : 0; }
     inline unsigned                getCurrentDiscIndex()    const { return (_diskControlInterface.get_image_index != NULL) ? _diskControlInterface.get_image_index() : 0; }
     void                           setCurrentDiscIndex(unsigned index);
-    bool                           getDiscLabel(unsigned index, std::string& label);
-    bool                           getDiscPath(unsigned index, std::string& path);
+    bool                           getDiscLabel(unsigned index, std::string& label) const;
+    bool                           getDiscPath(unsigned index, std::string& path) const;
     inline bool                    getTrayOpen()            const { return (_diskControlInterface.get_eject_state != NULL) ? (bool)_diskControlInterface.get_eject_state() : false; }
     void                           setTrayOpen(bool open);
 


### PR DESCRIPTION
implements #416 

Rather than support jumping to specific disks, I've implemented it such that there is one hotkey to eject/insert the disc, one for next disc, and one for previous disc.

The following are the defaults, but can be changed by the user. I chose to put eject in the middle to eliminate the need to reach over prev to get to next:
* Alt+0: Previous disk
* Alt+-: Eject/Insert
* Alt+=: Next disk