### PR TITLE
add option to capture mouse in game focus mode

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -125,6 +125,7 @@ protected:
   void        loadConfiguration(int* window_x, int* window_y, int* window_width, int* window_height);
   void        saveConfiguration();
   std::string serializeRecentList();
+  void        updateMouseCapture();
   void        updateSpeedIndicator();
   void        toggleFastForwarding(unsigned extra);
   void        toggleBackgroundInput();
@@ -180,4 +181,7 @@ protected:
 
   HMENU _menu;
   HMENU _cdRomMenu;
+
+  int _absViewMouseX;
+  int _absViewMouseY;
 };

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -95,6 +95,7 @@ bool Config::init(libretro::LoggerComponent* logger)
   _fastForwardRatio = 5;
   _backgroundInput = false;
   _showSpeedIndicator = true;
+  _gameFocusCaptureMouse = false;
 
   reset();
   return true;
@@ -570,6 +571,10 @@ std::string Config::serializeEmulatorSettings() const
 
   json.append("\"showSpeedIndicator\":");
   json.append(_showSpeedIndicator ? "true" : "false");
+  json.append(",");
+
+  json.append("\"gameFocusCaptureMouse\":");
+  json.append(_gameFocusCaptureMouse ? "true" : "false");
 
   json.append("}");
   return json;
@@ -607,6 +612,10 @@ bool Config::deserializeEmulatorSettings(const char* json)
       else if (ud->key == "showSpeedIndicator")
       {
         ud->self->_showSpeedIndicator = num != 0;
+      }
+      else if (ud->key == "gameFocusCaptureMouse")
+      {
+        ud->self->_gameFocusCaptureMouse = num != 0;
       }
     }
     else if (event == JSONSAX_NUMBER)
@@ -939,6 +948,10 @@ void Config::showEmulatorSettingsDialog()
   db.addCheckbox("Show Indicator when Paused or Fast Forwarding", 51004, 0, y, WIDTH - 10, 8, &showSpeedIndicator);
   y += LINE;
 
+  bool gameFocusCaptureMouse = _gameFocusCaptureMouse;
+  db.addCheckbox("Capture mouse in Game Focus mode", 51005, 0, y, WIDTH - 10, 8, &gameFocusCaptureMouse);
+  y += LINE;
+
   db.addButton("OK", IDOK, WIDTH - 55 - 50, y, 50, 14, true);
   db.addButton("Cancel", IDCANCEL, WIDTH - 50, y, 50, 14, false);
 
@@ -947,6 +960,7 @@ void Config::showEmulatorSettingsDialog()
     _audioWhileFastForwarding = playAudio;
     _fastForwardRatio = fastForwardRatio + 2;
     _showSpeedIndicator = showSpeedIndicator;
+    _gameFocusCaptureMouse = gameFocusCaptureMouse;
   }
 }
 #endif

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -60,6 +60,8 @@ public:
   virtual bool getShowSpeedIndicator() override { return _showSpeedIndicator; }
   virtual void setShowSpeedIndicator(bool value) override { _showSpeedIndicator = value; }
 
+  virtual bool getGameFocusCaptureMouse() override { return _gameFocusCaptureMouse; }
+
   void setSaveDirectory(const std::string& path) { _saveFolder = path; }
 
   const char* getRootFolder()
@@ -152,6 +154,7 @@ protected:
   bool _audioWhileFastForwarding;
   bool _backgroundInput;
   bool _showSpeedIndicator;
+  bool _gameFocusCaptureMouse;
 
   int _fastForwardRatio;
 

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -159,6 +159,8 @@ namespace libretro
 
     virtual bool getShowSpeedIndicator() = 0;
     virtual void setShowSpeedIndicator(bool value) = 0;
+
+    virtual bool getGameFocusCaptureMouse() = 0;
   };
 
   /**

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -164,6 +164,11 @@ namespace
     {
       (void)value;
     }
+
+    virtual bool getGameFocusCaptureMouse() override
+    {
+      return false;
+    }
   };
 
   class DummyVideoContext : public libretro::VideoContextComponent


### PR DESCRIPTION
Allows `RETRO_DEVICE_ID_MOUSE_X` and `RETRO_DEVICE_ID_MOUSE_Y` to return relative movements even when the mouse is outside the window.

`RETRO_DEVICE_ID_POINTER_X` and `RETRO_DEVICE_ID_POINTER_Y` still return absolute locations relative to the cursors location in the window.