### PR TITLE
don't unpause emulator when resetting

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2359,6 +2359,9 @@ void Application::handle(const SDL_SysWMEvent* syswm)
 
     case IDM_RESET_GAME:
       _fsm.resetGame();
+
+      if (isPaused())
+        _fsm.step();
       break;
     
     case IDM_SAVE_STATE_1:
@@ -2685,6 +2688,9 @@ void Application::handle(const KeyBinds::Action action, unsigned extra)
 
   case KeyBinds::Action::kReset:
     _fsm.resetGame();
+
+    if (isPaused())
+      _fsm.step();
     break;
 
   case KeyBinds::Action::kScreenshot:

--- a/src/Fsm.cpp
+++ b/src/Fsm.cpp
@@ -682,21 +682,17 @@ bool Fsm::resetGame() {
         return false;
       }
 
-      bool __ok = resumeGame() &&
-                  resetGame();
 
-      if (__ok) {
-        after(__state);
-        after();
+      ctx.resetGame();
 
-      }
-      else {
+      __state = State::GamePaused;
+      after(__state);
+      after();
+
 #ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
+      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
 #endif
-      }
-
-      return __ok;
+      return true;
     }
     break;
 
@@ -717,21 +713,17 @@ bool Fsm::resetGame() {
         return false;
       }
 
-      bool __ok = resumeGame() &&
-                  resetGame();
 
-      if (__ok) {
-        after(__state);
-        after();
+      ctx.resetGame();
 
-      }
-      else {
+      __state = State::GamePausedNoOvl;
+      after(__state);
+      after();
+
 #ifdef DEBUG_FSM
-        ctx.printf("FSM %s:%u Failed to switch to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
+      ctx.printf("FSM %s:%u Switched to %s", __FUNCTION__, __LINE__, stateName(State::GameRunning));
 #endif
-      }
-
-      return __ok;
+      return true;
     }
     break;
 

--- a/src/Fsm.fsm
+++ b/src/Fsm.fsm
@@ -129,7 +129,9 @@ fsm Fsm {
   GamePaused {
     resumeGame() => GameRunning;
 
-    resetGame() => resumeGame() => resetGame();
+    resetGame() => GamePaused {
+      ctx.resetGame();
+    }
 
     step() => FrameStep  {
       if (ctx.hardcore()) {
@@ -155,7 +157,9 @@ fsm Fsm {
 
     resumeGame() => GameRunning;
 
-    resetGame() => resumeGame() => resetGame();
+    resetGame() => GamePausedNoOvl {
+      ctx.resetGame();
+    }
 
     step() => FrameStep {
       if (ctx.hardcore()) {


### PR DESCRIPTION
Fixes an issue where the pause indicator remains on screen when the emulator is reset. Rather than remove the pause indicator, I felt it was more appropriate to not unpause the emulator when resetting. This allows developer to debug memory state as the emulator is reset.