### PR TITLE
update libchdr

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -51,7 +51,7 @@ endif
 
 ifdef HAVE_CHD
   CXXFLAGS += -DHAVE_CHD -I./src/libchdr/include
-  CFLAGS += -DZ7_ST -I./src/libchdr/include -I./src/libchdr/deps/lzma-24.05/include -I./src/libchdr/deps/zlib-1.3.1 -I./src/libchdr/deps/zstd-1.5.6/lib
+  CFLAGS += -DZ7_ST -DZSTD_DISABLE_ASM -I./src/libchdr/include -I./src/libchdr/deps/lzma-24.05/include -I./src/libchdr/deps/zlib-1.3.1 -I./src/libchdr/deps/zstd-1.5.6/lib
   CHD_OBJS = src/libchdr/deps/lzma-24.05/src/Alloc.o \
              src/libchdr/deps/lzma-24.05/src/Bra86.o \
              src/libchdr/deps/lzma-24.05/src/BraIA64.o \
@@ -59,7 +59,6 @@ ifdef HAVE_CHD
              src/libchdr/deps/lzma-24.05/src/Delta.o \
              src/libchdr/deps/lzma-24.05/src/LzFind.o \
              src/libchdr/deps/lzma-24.05/src/Lzma86Dec.o \
-             src/libchdr/deps/lzma-24.05/src/Lzma86Enc.o \
              src/libchdr/deps/lzma-24.05/src/LzmaDec.o \
              src/libchdr/deps/lzma-24.05/src/LzmaEnc.o \
              src/libchdr/deps/lzma-24.05/src/Sort.o \

--- a/Makefile.common
+++ b/Makefile.common
@@ -51,33 +51,45 @@ endif
 
 ifdef HAVE_CHD
   CXXFLAGS += -DHAVE_CHD -I./src/libchdr/include
-  CFLAGS += -D_7ZIP_ST -I./src/libchdr/include -I./src/libchdr/deps/lzma-22.01/include -I./src/libchdr/deps/zlib-1.2.12
-  CHD_OBJS = src/libchdr/deps/lzma-22.01/src/Alloc.o \
-             src/libchdr/deps/lzma-22.01/src/Bra86.o \
-             src/libchdr/deps/lzma-22.01/src/BraIA64.o \
-             src/libchdr/deps/lzma-22.01/src/CpuArch.o \
-             src/libchdr/deps/lzma-22.01/src/Delta.o \
-             src/libchdr/deps/lzma-22.01/src/LzFind.o \
-             src/libchdr/deps/lzma-22.01/src/Lzma86Dec.o \
-             src/libchdr/deps/lzma-22.01/src/Lzma86Enc.o \
-             src/libchdr/deps/lzma-22.01/src/LzmaDec.o \
-             src/libchdr/deps/lzma-22.01/src/LzmaEnc.o \
-             src/libchdr/deps/lzma-22.01/src/Sort.o \
-             src/libchdr/deps/zlib-1.2.12/adler32.o \
-             src/libchdr/deps/zlib-1.2.12/compress.o \
-             src/libchdr/deps/zlib-1.2.12/crc32.o \
-             src/libchdr/deps/zlib-1.2.12/deflate.o \
-             src/libchdr/deps/zlib-1.2.12/gzclose.o \
-             src/libchdr/deps/zlib-1.2.12/gzlib.o \
-             src/libchdr/deps/zlib-1.2.12/gzread.o \
-             src/libchdr/deps/zlib-1.2.12/gzwrite.o \
-             src/libchdr/deps/zlib-1.2.12/infback.o \
-             src/libchdr/deps/zlib-1.2.12/inffast.o \
-             src/libchdr/deps/zlib-1.2.12/inflate.o \
-             src/libchdr/deps/zlib-1.2.12/inftrees.o \
-             src/libchdr/deps/zlib-1.2.12/trees.o \
-             src/libchdr/deps/zlib-1.2.12/uncompr.o \
-             src/libchdr/deps/zlib-1.2.12/zutil.o \
+  CFLAGS += -DZ7_ST -I./src/libchdr/include -I./src/libchdr/deps/lzma-24.05/include -I./src/libchdr/deps/zlib-1.3.1 -I./src/libchdr/deps/zstd-1.5.6/lib
+  CHD_OBJS = src/libchdr/deps/lzma-24.05/src/Alloc.o \
+             src/libchdr/deps/lzma-24.05/src/Bra86.o \
+             src/libchdr/deps/lzma-24.05/src/BraIA64.o \
+             src/libchdr/deps/lzma-24.05/src/CpuArch.o \
+             src/libchdr/deps/lzma-24.05/src/Delta.o \
+             src/libchdr/deps/lzma-24.05/src/LzFind.o \
+             src/libchdr/deps/lzma-24.05/src/Lzma86Dec.o \
+             src/libchdr/deps/lzma-24.05/src/Lzma86Enc.o \
+             src/libchdr/deps/lzma-24.05/src/LzmaDec.o \
+             src/libchdr/deps/lzma-24.05/src/LzmaEnc.o \
+             src/libchdr/deps/lzma-24.05/src/Sort.o \
+             src/libchdr/deps/zlib-1.3.1/adler32.o \
+             src/libchdr/deps/zlib-1.3.1/compress.o \
+             src/libchdr/deps/zlib-1.3.1/crc32.o \
+             src/libchdr/deps/zlib-1.3.1/deflate.o \
+             src/libchdr/deps/zlib-1.3.1/gzclose.o \
+             src/libchdr/deps/zlib-1.3.1/gzlib.o \
+             src/libchdr/deps/zlib-1.3.1/gzread.o \
+             src/libchdr/deps/zlib-1.3.1/gzwrite.o \
+             src/libchdr/deps/zlib-1.3.1/infback.o \
+             src/libchdr/deps/zlib-1.3.1/inffast.o \
+             src/libchdr/deps/zlib-1.3.1/inflate.o \
+             src/libchdr/deps/zlib-1.3.1/inftrees.o \
+             src/libchdr/deps/zlib-1.3.1/trees.o \
+             src/libchdr/deps/zlib-1.3.1/uncompr.o \
+             src/libchdr/deps/zlib-1.3.1/zutil.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/debug.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/entropy_common.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/error_private.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/fse_decompress.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/pool.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/threading.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/xxhash.o \
+             src/libchdr/deps/zstd-1.5.6/lib/common/zstd_common.o \
+             src/libchdr/deps/zstd-1.5.6/lib/decompress/huf_decompress.o \
+             src/libchdr/deps/zstd-1.5.6/lib/decompress/zstd_ddict.o \
+             src/libchdr/deps/zstd-1.5.6/lib/decompress/zstd_decompress.o \
+             src/libchdr/deps/zstd-1.5.6/lib/decompress/zstd_decompress_block.o \
              src/libchdr/src/libchdr_bitstream.o \
              src/libchdr/src/libchdr_cdrom.o \
              src/libchdr/src/libchdr_chd.o \

--- a/src/libchdr.vcxproj
+++ b/src/libchdr.vcxproj
@@ -55,9 +55,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_7ZIP_ST;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;Z7_ST;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
-      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-22.01\include;$(ProjectDir)libchdr\deps\zlib-1.2.12;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-24.05\include;$(ProjectDir)libchdr\deps\zstd-1.5.6\lib;$(ProjectDir)libchdr\deps\zlib-1.3.1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
       <ConformanceMode>true</ConformanceMode>
       <WarningLevel>Level2</WarningLevel>
@@ -69,22 +69,18 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <Lib />
     <Lib>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Lib>
-    <PreBuildEvent>
-      <Command>IF NOT EXIST $(ProjectDir)libchdr\deps\zalib-1.2.12\zconf.h COPY $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h.included $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_7ZIP_ST;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;Z7_ST;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
-      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-22.01\include;$(ProjectDir)libchdr\deps\zlib-1.2.12;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-24.05\include;$(ProjectDir)libchdr\deps\zstd-1.5.6\lib;$(ProjectDir)libchdr\deps\zlib-1.3.1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
       <ConformanceMode>true</ConformanceMode>
       <WarningLevel>Level2</WarningLevel>
@@ -97,20 +93,16 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <Lib />
     <Lib>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Lib>
-    <PreBuildEvent>
-      <Command>IF NOT EXIST $(ProjectDir)libchdr\deps\zalib-1.2.12\zconf.h COPY $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h.included $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_7ZIP_ST;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;Z7_ST;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
-      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-22.01\include;$(ProjectDir)libchdr\deps\zlib-1.2.12;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-24.05\include;$(ProjectDir)libchdr\deps\zstd-1.5.6\lib;$(ProjectDir)libchdr\deps\zlib-1.3.1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
@@ -120,18 +112,13 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <Lib />
-    <Lib />
-    <PreBuildEvent>
-      <Command>IF NOT EXIST $(ProjectDir)libchdr\deps\zalib-1.2.12\zconf.h COPY $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h.included $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_7ZIP_ST;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;Z7_ST;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsC</CompileAs>
-      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-22.01\include;$(ProjectDir)libchdr\deps\zlib-1.2.12;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)libchdr\include;$(ProjectDir)libchdr\deps\lzma-24.05\include;$(ProjectDir)libchdr\deps\zstd-1.5.6\lib;$(ProjectDir)libchdr\deps\zlib-1.3.1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
@@ -142,39 +129,45 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <Lib />
-    <Lib />
-    <PreBuildEvent>
-      <Command>IF NOT EXIST $(ProjectDir)libchdr\deps\zalib-1.2.12\zconf.h COPY $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h.included $(ProjectDir)libchdr\deps\zlib-1.2.12\zconf.h</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Alloc.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Bra86.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\BraIA64.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\CpuArch.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Delta.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzFind.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Lzma86Dec.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Lzma86Enc.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzmaDec.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzmaEnc.c" />
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Sort.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\adler32.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\compress.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\crc32.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\deflate.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzclose.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzlib.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzread.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzwrite.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\infback.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inffast.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inflate.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inftrees.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\trees.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\uncompr.c" />
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\zutil.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Alloc.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Bra86.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\BraIA64.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\CpuArch.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Delta.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzFind.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Lzma86Dec.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzmaDec.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzmaEnc.c" />
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Sort.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\adler32.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\compress.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\crc32.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\deflate.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzclose.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzlib.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzread.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzwrite.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\infback.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inffast.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inflate.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inftrees.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\trees.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\uncompr.c" />
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\zutil.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\debug.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\entropy_common.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\error_private.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\fse_decompress.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\pool.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\threading.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\xxhash.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\zstd_common.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\huf_decompress.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_ddict.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_decompress.c" />
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_decompress_block.c" />
     <ClCompile Include="libchdr\src\libchdr_bitstream.c" />
     <ClCompile Include="libchdr\src\libchdr_cdrom.c" />
     <ClCompile Include="libchdr\src\libchdr_chd.c" />

--- a/src/libchdr.vcxproj.filters
+++ b/src/libchdr.vcxproj.filters
@@ -10,6 +10,15 @@
     <Filter Include="lzma">
       <UniqueIdentifier>{ad972f61-02df-4c5a-af25-b997be37894e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="zstd">
+      <UniqueIdentifier>{b2f0fccc-ffbd-4f14-8ca3-932cbaa6f40a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="zstd\common">
+      <UniqueIdentifier>{71dd06ce-b02e-479d-b4a3-925e844d3690}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="zstd\decompress">
+      <UniqueIdentifier>{c00242e4-c3dc-4570-8f3f-ee04033a440c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="libchdr\src\libchdr_bitstream.c">
@@ -27,83 +36,116 @@
     <ClCompile Include="libchdr\src\libchdr_huffman.c">
       <Filter>libchdr</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\adler32.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\adler32.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\compress.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\compress.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\crc32.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\crc32.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\deflate.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\deflate.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzclose.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzclose.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzlib.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzlib.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzread.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzread.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\gzwrite.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\gzwrite.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\infback.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\infback.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inffast.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inffast.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inflate.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inflate.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\inftrees.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\inftrees.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\trees.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\trees.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\uncompr.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\uncompr.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\zlib-1.2.12\zutil.c">
+    <ClCompile Include="libchdr\deps\zlib-1.3.1\zutil.c">
       <Filter>zlib</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Lzma86Dec.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Lzma86Dec.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzmaDec.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzmaDec.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzmaEnc.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzmaEnc.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\LzFind.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\LzFind.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\CpuArch.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\CpuArch.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Sort.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Sort.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Alloc.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Alloc.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Bra86.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Bra86.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\BraIA64.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\BraIA64.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Delta.c">
+    <ClCompile Include="libchdr\deps\lzma-24.05\src\Delta.c">
       <Filter>lzma</Filter>
     </ClCompile>
-    <ClCompile Include="libchdr\deps\lzma-22.01\src\Lzma86Enc.c">
-      <Filter>lzma</Filter>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\zstd_common.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\debug.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\entropy_common.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\error_private.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\fse_decompress.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\pool.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\threading.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\common\xxhash.c">
+      <Filter>zstd\common</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_decompress_block.c">
+      <Filter>zstd\decompress</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\huf_decompress.c">
+      <Filter>zstd\decompress</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_ddict.c">
+      <Filter>zstd\decompress</Filter>
+    </ClCompile>
+    <ClCompile Include="libchdr\deps\zstd-1.5.6\lib\decompress\zstd_decompress.c">
+      <Filter>zstd\decompress</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Primarily adds support for zstd compression. Also includes some bugfixes and performance improvements.

libchdr still _DOES NOT_ support images created with `createdvd`.