### PR TITLE
Add Ardens core to cores.json

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -4,6 +4,10 @@
     "systems": [31],
     "platforms": "none"
   },
+  "ardens_libretro":{
+    "name": "Ardens",
+    "systems": [71]
+  },
   "arduous_libretro":{
     "name": "Arduous",
     "systems": [71]


### PR DESCRIPTION
Added Ardens to the list of available Arduboy cores in order to support Arduboy FX games