### PR TITLE
don't read past end of CHD track

### DIFF
--- a/src/HashCHD.cpp
+++ b/src/HashCHD.cpp
@@ -100,9 +100,11 @@ static bool rc_hash_get_chd_metadata(chd_file* file, uint32_t idx, metadata_t* m
     err = chd_get_metadata(file, CHD_MAKE_TAG('D', 'V', 'D', ' '), idx, meta, sizeof(meta), &meta_size, NULL, NULL);
     if (err == CHDERR_NONE)
     {
+      const chd_header* header = chd_get_header(file);
       /* DVD-ROM track doesn't have metadata. It's just raw 2048 byte sectors with no header/footer (MODE1) */
       memset(metadata, 0, sizeof(metadata));
       metadata->track = 1;
+      metadata->frames = header->unitcount;
       memcpy(metadata->type, "MODE1", strlen("MODE1") + 1);
       return true;
     }


### PR DESCRIPTION
Fixes https://github.com/RetroAchievements/RAIntegration/issues/1142

The logic for hashing a Dreamcast CD looks for the executable in track 3. If it's not found in track 3, it looks in the last data track. In both cases, the code just says "open track 3, fetch data at sector Y, if that fails, open track LAST, fetch data at sector Y".

When processing a CHD, we weren't checking if sector Y existed in track X, so it would blindly go find data some Y sectors after the start of track 3. Because of padding between tracks, this wasn't the executable and the hash would be wrong.