### PR TITLE
Fix copy command for paths with + char

### DIFF
--- a/src/RAHasher.vcxproj
+++ b/src/RAHasher.vcxproj
@@ -89,7 +89,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <CustomBuildStep>
-      <Command>copy /b/y  $(TargetPath) $(SolutionDir)\bin64</Command>
+      <Command>copy /b/y  "$(TargetPath)" "$(SolutionDir)\bin64"</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Copying $(TargetFileName) to bin64 directory</Message>

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -132,7 +132,7 @@ $(ProjectDir)RAInterface\CopyOverlay.bat $(SolutionDir)bin</Command>
       <AdditionalDependencies>SDL2main.lib;SDL2.lib;dinput8.lib;winmm.lib;imm32.lib;version.lib;winhttp.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
-      <Command>copy /b/y $(TargetPath) $(SolutionDir)\bin64</Command>
+      <Command>copy /b/y "$(TargetPath)" "$(SolutionDir)\bin64"</Command>
       <Outputs>$(SolutionDir)\bin64\$(TargetFileName)</Outputs>
       <Inputs>$(TargetPath)</Inputs>
       <Message>Copying $(TargetFileName) to bin64 directory</Message>


### PR DESCRIPTION
The copy DOS command will not work with unquoted paths with `+` characters; it tries to interpret them as additional source files.

I ran into this issue with a `C++` folder name.