### PR TITLE
add Ardens as valid core for arduboy with arduboyfx support

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -4,6 +4,10 @@
     "systems": [31],
     "platforms": "none"
   },
+  "ardens_libretro":{
+    "name": "Ardens",
+    "systems": [71]
+  },
   "arduous_libretro":{
     "name": "Arduous",
     "systems": [71]

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -115,6 +115,7 @@ bool romLoaded(libretro::Core* core, Logger* logger, int system, const std::stri
     if (!hash[0])
     {
       struct rc_hash_filereader filereader;
+      rc_hash_iterator_t hash_iterator;
       std::string ext = util::extension(path);
 
       /* register a custom file_open handler for unicode support. use the default implementation for the other methods */
@@ -152,8 +153,8 @@ bool romLoaded(libretro::Core* core, Logger* logger, int system, const std::stri
         initHash3DS(core->getSystemDirectory());
 
       /* generate a hash for the new content */
-      if (!rom || !rc_hash_generate_from_buffer(hash, system, (uint8_t*)rom, size))
-        rc_hash_generate_from_file(hash, (int)system, path.c_str());
+      rc_hash_initialize_iterator(&hash_iterator, path.c_str(), (const uint8_t*)rom, size);
+      rc_hash_generate(hash, (int)system, &hash_iterator);
     }
 
     /* identify the game associated to the hash */


### PR DESCRIPTION
see also #436 

This supports the new hashing logic added for `.arduboy` files as described in https://github.com/RetroAchievements/rcheevos/pull/434

I had no troubles loading Prince of Arabia (core version 0.24.4) in RALibretro. I did not try in RetroArch.
![image](https://github.com/user-attachments/assets/9c4b475c-1c6b-42e7-8ea1-d24fdc8dc765)

I also had no troubles loading Dazzle Dash or Bytes & Knights, though neither of them appeared in the linked issue reporting issues in RetroArch.