### PR TITLE
fix ability to load extended states created in previous session

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1872,8 +1872,11 @@ void Application::saveState(unsigned ndx)
   snprintf(message, sizeof(message), "Saved state %u", ndx);
   _video.showMessage(message, 60);
 
-  _validSlots |= 1 << ndx;
-  enableSlots();
+  if (ndx <= 10)
+  {
+    _validSlots |= 1 << ndx;
+    enableSlots();
+  }
 }
 
 void Application::saveState()
@@ -1906,7 +1909,12 @@ void Application::loadState(unsigned ndx)
     return;
   }
 
-  if ((_validSlots & (1 << ndx)) == 0)
+  if (ndx > 10)
+  {
+    // we don't pre-validate the existance of save states that aren't displayed in the menu
+    // also, we can't track more than 32 states that way and allow up to 99 numbered states
+  }
+  else if ((_validSlots & (1 << ndx)) == 0)
   {
     return;
   }


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/453242743292952578/1368595061276803104

The logic to "remember" which states exist was tied to the menu, which only tracks the first 10 states. Additional states (up to 31) would be remembered within the current session, but forgotten when restarting RALibretro.