### PR TITLE
preparation for split of FDS from NES

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -164,7 +164,14 @@
   },
   "fceumm_libretro":{
     "name": "FCEUmm",
+    "extensions": "nes|fds",
     "systems": [7]
+  },
+  "fceumm_libretro":{
+    "name": "FCEUmm",
+    "extensions": "fds",
+    "systems": [81],
+    "platforms": "none"
   },
   "flycast_libretro":{
     "name": "Flycast",
@@ -458,7 +465,14 @@
   },
   "mesen_libretro":{
     "name": "Mesen",
+    "extensions": "nes|fds",
     "systems": [7]
+  },
+  "mesen_libretro":{
+    "name": "Mesen",
+    "extensions": "fds",
+    "systems": [81],
+    "platforms": "none"
   },
   "mesen-s_libretro":{
     "name": "Mesen-S",

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -864,6 +864,7 @@ bool Application::loadCore(const std::string& coreName)
   case RC_CONSOLE_APPLE_II:
   case RC_CONSOLE_ATARI_ST:
   case RC_CONSOLE_COMMODORE_64:
+  case RC_CONSOLE_FAMICOM_DISK_SYSTEM:
   case RC_CONSOLE_MS_DOS:
   case RC_CONSOLE_MSX:
   case RC_CONSOLE_NINTENDO: // FDS

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -304,6 +304,7 @@ const char* getSystemManufacturer(int system)
 {
   switch (system)
   {
+    case RC_CONSOLE_FAMICOM_DISK_SYSTEM:
     case RC_CONSOLE_GAMEBOY:
     case RC_CONSOLE_GAMEBOY_COLOR:
     case RC_CONSOLE_GAMEBOY_ADVANCE:


### PR DESCRIPTION
The fceumm and mesen cores.json changes are temporarily disabled until a new DLL can be released as the dll will complain about a mismatch between the client registering FDS memory and the game being returned as NES. Users wanting to test the functionality can remove the "platforms:none" from the "systems:81" entries if they have access to an updated DLL.

https://discord.com/channels/310192285306454017/1124566547797655692/1310992211730763888
https://discord.com/channels/310192285306454017/1124566547797655692/1311347053934149732