### PR TITLE
remove xp support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   RALibretro-Win32:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -22,13 +22,11 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
     - name: Build
       run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x86
 
   RALibretro-Win64:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -36,8 +34,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install Windows SDK 8.1
-      run: choco install windows-sdk-8.1
     - name: Build
       run: msbuild.exe RALibretro.sln -p:Configuration=Release -p:Platform=x64
 

--- a/src/RALibretro.vcxproj
+++ b/src/RALibretro.vcxproj
@@ -23,8 +23,7 @@
     <ProjectGuid>{418D11DE-D07C-4BF2-A454-ACCCB451BBE1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <ConfigurationType>Application</ConfigurationType>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <OutDir>$(SolutionDir)\obj\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
@@ -36,6 +35,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define WINDOWS_IGNORE_PACKING_MISMATCH 1 // prevent "Windows headers require the default packing option" error - need to upgrade SDL library to fix it
+
 #include <SDL.h>
 #include <SDL_syswm.h>
 


### PR DESCRIPTION
GitHub is dropping support for the Windows Server 2019 build image, which was the last version that supported the additional libraries needed for targeting Windows XP. 

> The Windows Server 2019 runner image will be fully unsupported by June 30, 2025.

This PR updates the project to target Windows 10, but I've verified the binary does still run in both my Windows 7 VM and Windows Vista VMs