### PR TITLE
show error message if no audio device is found

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -236,6 +236,7 @@ bool Application::init(const char* title, int width, int height)
   if (_audioDev == 0)
   {
     _logger.error(TAG "SDL_OpenAudioDevice: %s", SDL_GetError());
+    MessageBox(g_mainWindow, "No audio device found", "Initialization failed", MB_OK);
     goto error;
   }
 


### PR DESCRIPTION
Currently, if no audio device is found during initialization, an error is logged, then the application quits. This is very confusing for the user. 

This adds a visual popup telling the user that no audio device was found.