### PR TITLE
update dynamic menu visibility on config dialog close

### DIFF
--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -96,6 +96,7 @@ bool Config::init(libretro::LoggerComponent* logger)
   _backgroundInput = false;
   _showSpeedIndicator = true;
   _gameFocusCaptureMouse = false;
+  memset(&_updateDisplayCallback, 0, sizeof(_updateDisplayCallback));
 
   reset();
   return true;
@@ -324,6 +325,11 @@ void Config::setVariableDisplay(const struct retro_core_option_display* display)
   }
 
   _logger->info(TAG "Could not set visibility on unknown variable %s", display->key);
+}
+
+void Config::setUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data)
+{
+  memcpy(&_updateDisplayCallback, data, sizeof(_updateDisplayCallback));
 }
 
 bool Config::varUpdated()
@@ -906,6 +912,9 @@ void Config::showDialog(const std::string& coreName, Input& input)
         _selections[var._key] = var._options[var._selected];
       }
     }
+
+    if (_updateDisplayCallback.callback)
+      _updateDisplayCallback.callback();
   }
 }
 

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -45,6 +45,7 @@ public:
   virtual void setVariables(const struct retro_core_option_v2_definition* options, unsigned count,
     const struct retro_core_option_v2_category* categories, unsigned category_count) override;
   virtual void setVariableDisplay(const struct retro_core_option_display* display) override;
+  virtual void setUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data) override;
   virtual bool varUpdated() override;
   virtual const char* getVariable(const char* variable) override;
 
@@ -147,6 +148,7 @@ protected:
   std::vector<Category> _categories;
   std::vector<Variable> _variables;
   std::unordered_map<std::string, std::string> _selections;
+  struct retro_core_options_update_display_callback _updateDisplayCallback;
 
   bool _updated;
   bool _fastForwarding;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -145,6 +145,7 @@ namespace libretro
     virtual void setVariables(const struct retro_core_option_v2_definition* options, unsigned count,
       const struct retro_core_option_v2_category* categories, unsigned category_count) = 0;
     virtual void setVariableDisplay(const struct retro_core_option_display* display) = 0;
+    virtual void setUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data) = 0;
     virtual bool varUpdated() = 0;
     virtual const char* getVariable(const char* variable) = 0;
 

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -114,6 +114,11 @@ namespace
       (void)display;
     }
 
+    virtual void setUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data) override
+    {
+      (void)data;
+    }
+
     virtual bool varUpdated() override
     {
       return false;
@@ -1792,6 +1797,13 @@ bool libretro::Core::setCoreOptionsDisplay(const struct retro_core_option_displa
   return true;
 }
 
+bool libretro::Core::setCoreOptionsUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data)
+{
+  _config->setUpdateDisplayCallback(data);
+  return true;
+}
+
+
 static bool clearAllWaitThreadsCallback(unsigned clear_threads, void* data)
 {
   return true;
@@ -2079,10 +2091,13 @@ bool libretro::Core::environmentCallback(unsigned cmd, void* data)
     ret = getMicrophoneInterface((struct retro_microphone_interface*)data);
     break;
 
-  /* RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK cannot be supported because
-   * we don't update the variable values in real time. values are only updated when the config
-   * dialog is closed.
-   */
+  case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK:
+    /* NOTE: we don't update the variable values in real time. values are only updated when the config
+     * dialog is closed. As such, the update display callback is only called after the dialog is closed
+     * and the updated visibility is only reflected the next time the user opens the dialog.
+     */
+    ret = setCoreOptionsUpdateDisplayCallback((const struct retro_core_options_update_display_callback*)data);
+    break;
 
   case RETRO_ENVIRONMENT_SET_SAVE_STATE_IN_BACKGROUND:
     _logger->warn(TAG "Unimplemented env call: %s", "RETRO_ENVIRONMENT_SET_SAVE_STATE_IN_BACKGROUND");

--- a/src/libretro/Core.h
+++ b/src/libretro/Core.h
@@ -178,6 +178,7 @@ namespace libretro
     bool setCoreOptionsV2(const struct retro_core_options_v2* data);
     bool setCoreOptionsV2Intl(const struct retro_core_options_v2_intl* data);
     bool setCoreOptionsDisplay(const struct retro_core_option_display* data);
+    bool setCoreOptionsUpdateDisplayCallback(const struct retro_core_options_update_display_callback* data);
     bool getPreferredHWRender(unsigned* data);
     bool getMicrophoneInterface(struct retro_microphone_interface* data);
 


### PR DESCRIPTION
Minimally addresses https://discord.com/channels/310192285306454017/353363923333808128/1227370418499883008

`RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK` is designed to toggle the visibility of config options as the user changes values. However, that relies on the updated value being written back to the core, which RAlibretro only does if the user hits the OK button on the configuration dialog.

As such, we previously decided not to handle the callback at all. However, it's still desirable to pick up the menu visibility changes after the setting is applied in case the user reopens the configuration dialog. Previously, the user would have to reload the core to pick up the visibility changes.

This is still not an optimal solution as the hidden settings that should be visible based on changing another setting remain hidden until the dialog is closed and reopened. However, there's nothing in the libretro API that allows us to notify the core of an option change without actually changing the option. RetroArch doesn't have an OK/Cancel paradigm for changing values. Values are changed immediately and the only way to revert the change is to manually set the selection back to the previous value. We could potentially keep a ledger of all changes made while the dialog is open and roll them back if the user hits cancel, but the changes would still be immediately applied to the core, which is undesirable in the case where the user hits cancel.

