### PR TITLE
support m3u of CHDs

### DIFF
--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -129,6 +129,19 @@ bool romLoaded(libretro::Core* core, Logger* logger, int system, const std::stri
       filereader.open = rhash_file_open;
       rc_hash_init_custom_filereader(&filereader);
 
+      if (ext.length() == 4 && tolower(ext[1]) == 'm' && ext[2] == '3' && tolower(ext[3]) == 'u')
+      {
+        for (int i = 0; i < core->getNumDiscs(); ++i)
+        {
+          std::string discPath;
+          if (core->getDiscPath(i, discPath))
+          {
+            ext = util::extension(discPath);
+            break;
+          }
+        }
+      }
+
       if (ext.length() == 4 && tolower(ext[1]) == 'c' && tolower(ext[2]) == 'h' && tolower(ext[3]) == 'd')
       {
 #ifdef HAVE_CHD


### PR DESCRIPTION
ensures the CHD decoder gets registered if the first disc in an m3u is a chd.