### PR TITLE
don't enable fceumm for fds by default as it doesn't expose FDS extended RAM

### DIFF
--- a/bin/Cores/cores.json
+++ b/bin/Cores/cores.json
@@ -170,7 +170,8 @@
   "fceumm_libretro":{
     "name": "FCEUmm",
     "extensions": "fds",
-    "systems": [81]
+    "systems": [81],
+    "platforms": "none"
   },
   "flycast_libretro":{
     "name": "Flycast",


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1479118678749479023
https://discord.com/channels/476211979464343552/1002689485005406249/1478427314231709776