### PR TITLE
never pass buffered cue file to hasher

### DIFF
--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -1169,8 +1169,8 @@ bool libretro::Core::getNeedsFullPath(const std::string& extension) const
   if (_contentInfoOverride && extensionMatches(_contentInfoOverride->extensions, extension))
     return _contentInfoOverride->need_fullpath;
 
-  /* never pass a buffered m3u to the core, even if the core suggests that's okay. */
-  if (extensionMatches("m3u", extension))
+  /* never pass a buffered m3u or cue file to the core, even if the core suggests that's okay. */
+  if (extensionMatches("m3u", extension) || extensionMatches("cue", extension))
     return true;
 
   return _systemInfo.need_fullpath;


### PR DESCRIPTION
Fixes an issue where attempting to load a Sega CD cue file in the picodrive core reports "unsupported console for buffer hash".

The behavioral override extensions for the PicoDrive core were updated to include "cue" [last November](https://github.com/libretro/picodrive/commit/9e304a66eb3041df45452b79e596fd1c2572cee3#diff-60cdbe462ad5f4c9234d624b8d0503a676f6577f0022d80eee5b04c5e0bf648bR631).

As a result, the frontend uses the `needs_fullpath` from the [content override data](https://github.com/libretro/RetroArch/blob/8cbd0f1eacf59f263b695fd11baf5a864736cb1e/libretro-common/include/libretro.h#L6215) instead of the `needs_fullpath` from the [system info](https://github.com/libretro/RetroArch/blob/8cbd0f1eacf59f263b695fd11baf5a864736cb1e/libretro-common/include/libretro.h#L6117), and the content override data does not claim it needs the full path, so the cue file gets buffered and then it attempts to hash the cue file instead of loading the associated disc.