### PR TITLE
remember previous folder selection per system

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -149,7 +149,7 @@ bool Application::init(const char* title, int width, int height)
   inited = kSdlInited;
 
   // keybinds must be initialized before calling loadConfiguration
-  if (!_keybinds.init(&_logger))
+  if (!_keybinds.init(&_logger, &_config))
   {
     goto error;
   }
@@ -1598,10 +1598,12 @@ void Application::loadGame()
   file_types.append("*.*");
   file_types.append("\0", 2);
 
-  std::string path = util::openFileDialog(g_mainWindow, file_types);
+  std::string path = util::openFileDialog(g_mainWindow, file_types, _config.getRomPath(_system));
 
   if (!path.empty())
   {
+    _config.setRomPath(_system, util::directory(path));
+
     /* some cores need to be reset to flush any previous state information */
     /* this also ensures the disc menu is reset if the core built it dynamically */
     /* ASSERT: loadCore will unload the current core, even if it's the same core */
@@ -1965,10 +1967,12 @@ void Application::loadState()
   extensions.append("\0", 1);
   extensions.append("*.*");
   extensions.append("\0", 2);
-  std::string path = util::openFileDialog(g_mainWindow, extensions);
+  std::string path = util::openFileDialog(g_mainWindow, extensions, _config.getRomPath(_system));
 
   if (!path.empty())
   {
+    _config.setRomPath(_system, util::directory(path));
+
     loadState(path);
   }
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1913,7 +1913,7 @@ void Application::saveState()
   extensions.append("\0", 1);
   extensions.append("*.state");
   extensions.append("\0", 2);
-  std::string path = util::saveFileDialog(g_mainWindow, extensions, "state");
+  std::string path = util::saveFileDialog(g_mainWindow, extensions, "state", _config.getRomPath(_system));
 
   if (!path.empty())
   {

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -21,6 +21,7 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Util.h"
 
+#include "components/Config.h"
 #include "components/Dialog.h"
 #include "components/Input.h"
 
@@ -248,11 +249,12 @@ static const char* bindingNames[] = {
 };
 static_assert(sizeof(bindingNames) / sizeof(bindingNames[0]) == kMaxBindings, "bindingNames does not contain an appropriate number of elements");
 
-bool KeyBinds::init(Logger* logger)
+bool KeyBinds::init(Logger* logger, Config *config)
 {
   static_assert(sizeof(_bindings) / sizeof(_bindings[0]) == kMaxBindings, "BindingList does not contain an appropriate number of elements");
 
   _logger = logger;
+  _config = config;
   _slot = 1;
   _gameFocus = false;
   memset(_axesHeld, 0, sizeof(_axesHeld));
@@ -1792,6 +1794,7 @@ public:
   Input* _input = nullptr;
   std::map<SDL_JoystickID, SDL_JoystickID>* _bindingMap = nullptr;
   Logger* _logger = nullptr;
+  Config* _config = nullptr;
 
   const KeyBinds::BindingList& getBindings() const { return _bindings; }
 
@@ -1929,7 +1932,7 @@ protected:
     extensions.append("\0", 1);
     extensions.append("*.json");
     extensions.append("\0", 2);
-    std::string path = util::openFileDialog(hwnd, extensions);
+    std::string path = util::openFileDialog(hwnd, extensions, _config->getRootFolder());
 
     if (!path.empty())
     {
@@ -1993,6 +1996,7 @@ void KeyBinds::showControllerDialog(Input& input, int port)
   db._input = &input;
   db._bindingMap = &_bindingMap;
   db._logger = _logger;
+  db._config = _config;
 
   switch (port)
   {

--- a/src/KeyBinds.cpp
+++ b/src/KeyBinds.cpp
@@ -1897,7 +1897,7 @@ protected:
     extensions.append("\0", 1);
     extensions.append("*.json");
     extensions.append("\0", 2);
-    std::string path = util::saveFileDialog(hwnd, extensions, "json");
+    std::string path = util::saveFileDialog(hwnd, extensions, "json", _config->getRootFolder());
 
     if (!path.empty())
     {

--- a/src/KeyBinds.h
+++ b/src/KeyBinds.h
@@ -27,6 +27,7 @@ along with RALibretro.  If not, see <http://www.gnu.org/licenses/>.
 #include <map>
 
 class Input; // forward reference
+class Config; // forward reference
 
 class KeyBinds
 {
@@ -96,7 +97,7 @@ public:
     kKeyboardInput  // (extra = key << 8 | pressed)
   };
 
-  bool init(Logger* logger);
+  bool init(Logger* logger, Config* config);
   void destroy() {}
 
   Action translate(const SDL_KeyboardEvent* event, unsigned* extra);
@@ -136,7 +137,8 @@ public:
   bool hasGameFocus() const noexcept { return _gameFocus; }
 
 protected:
-  Logger* _logger;
+  Logger* _logger = nullptr;
+  Config* _config = nullptr;
 
   KeyBinds::Action translateButtonPress(int button, unsigned* extra);
   KeyBinds::Action translateButtonReleased(int button, unsigned* extra);
@@ -148,9 +150,9 @@ protected:
 
   std::map<SDL_JoystickID, SDL_JoystickID> _bindingMap;
 
-  unsigned _slot;
-  bool _gameFocus;
+  unsigned _slot = 1;
+  bool _gameFocus = false;
 
-  uint8_t _axesHeld[4];
+  uint8_t _axesHeld[4] = {};
 };
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -696,9 +696,10 @@ std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter,
   return "";
 }
 
-std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension)
+std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension, const std::string& initialDirectory)
 {
   std::wstring unicodeExtensionsFilter = util::utf8ToUChar(extensionsFilter);
+  std::wstring unicodeInitialDirectory = util::utf8ToUChar(initialDirectory);
   std::wstring unicodeDefaultExtension;
   wchar_t path[_MAX_PATH];
   path[0] = 0;
@@ -714,6 +715,9 @@ std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter,
   cfg.nMaxFile = sizeof(path)/sizeof(path[0]);
   cfg.lpstrTitle = L"Save";
   cfg.Flags = OFN_NOREADONLYRETURN | OFN_OVERWRITEPROMPT;
+
+  if (!initialDirectory.empty())
+    cfg.lpstrInitialDir = unicodeInitialDirectory.c_str();
 
   if (defaultExtension)
   {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -668,9 +668,10 @@ void util::ensureDirectoryExists(const std::string& directory)
 #endif
 
 #ifdef _WINDOWS
-std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)
+std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter, const std::string& initialDirectory)
 {
   std::wstring unicodeExtensionsFilter = util::utf8ToUChar(extensionsFilter);
+  std::wstring unicodeInitialDirectory = util::utf8ToUChar(initialDirectory);
   wchar_t path[_MAX_PATH];
   path[0] = 0;
 
@@ -686,14 +687,13 @@ std::string util::openFileDialog(HWND hWnd, const std::string& extensionsFilter)
   cfg.lpstrTitle = L"Load";
   cfg.Flags = OFN_FILEMUSTEXIST;
 
+  if (!unicodeInitialDirectory.empty())
+    cfg.lpstrInitialDir = unicodeInitialDirectory.c_str();
+
   if (GetOpenFileNameW(&cfg) == TRUE)
-  {
     return util::ucharToUtf8(path);
-  }
-  else
-  {
-    return "";
-  }
+
+  return "";
 }
 
 std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension)
@@ -722,13 +722,9 @@ std::string util::saveFileDialog(HWND hWnd, const std::string& extensionsFilter,
   }
 
   if (GetSaveFileNameW(&cfg) == TRUE)
-  {
     return util::ucharToUtf8(path);
-  }
-  else
-  {
-    return "";
-  }
+
+  return "";
 }
 #endif
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -77,7 +77,7 @@ namespace util
 #endif
 
 #ifdef _WINDOWS
-  std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter);
+  std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter, const std::string& initialDirectory);
   std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension = NULL);
 #endif
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -78,7 +78,7 @@ namespace util
 
 #ifdef _WINDOWS
   std::string openFileDialog(HWND hWnd, const std::string& extensionsFilter, const std::string& initialDirectory);
-  std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension = NULL);
+  std::string saveFileDialog(HWND hWnd, const std::string& extensionsFilter, const char* defaultExtension, const std::string& initialDirectory);
 #endif
 
   const void* toPng(Logger* logger, const void* data, unsigned width, unsigned height, unsigned pitch, enum retro_pixel_format format, int* len);

--- a/src/components/Config.cpp
+++ b/src/components/Config.cpp
@@ -125,6 +125,16 @@ const char* Config::getSystemPath()
   return _systemFolder.c_str();
 }
 
+const std::string& Config::getRomPath(int system_id)
+{
+  return _romFolders[system_id];
+}
+
+void Config::setRomPath(int system_id, const std::string& path)
+{
+  _romFolders[system_id] = path;
+}
+
 void Config::setVariables(const struct retro_variable* variables, unsigned count)
 {
   _variables.clear();
@@ -583,6 +593,22 @@ std::string Config::serializeEmulatorSettings() const
   json.append("\"gameFocusCaptureMouse\":");
   json.append(_gameFocusCaptureMouse ? "true" : "false");
 
+  const char* comma = "";
+  json.append(",\"romFolders\":{");
+  for (const auto& pair : _romFolders)
+  {
+    json.append(comma);
+    comma = ",";
+
+    json.append("\"");
+    json.append(std::to_string(pair.first));
+    json.append("\":\"");
+    json.append(util::jsonEscape(pair.second));
+    json.append("\"");
+  }
+
+  json.append("}");
+
   json.append("}");
   return json;
 }
@@ -602,40 +628,62 @@ bool Config::deserializeEmulatorSettings(const char* json)
   {
     auto ud = (Deserialize*)udata;
 
-    if (event == JSONSAX_KEY)
+    switch (event)
     {
-      ud->key = std::string(str, num);
-    }
-    else if (event == JSONSAX_BOOLEAN)
-    {
-      if (ud->key == "audioWhileFastForwarding" || ud->key == "_audioWhileFastForwarding")
-      {
-        ud->self->_audioWhileFastForwarding = num != 0;
-      }
-      else if (ud->key == "backgroundInput")
-      {
-        ud->self->_backgroundInput = num != 0;
-      }
-      else if (ud->key == "showSpeedIndicator")
-      {
-        ud->self->_showSpeedIndicator = num != 0;
-      }
-      else if (ud->key == "gameFocusCaptureMouse")
-      {
-        ud->self->_gameFocusCaptureMouse = num != 0;
-      }
-    }
-    else if (event == JSONSAX_NUMBER)
-    {
-      if (ud->key == "fastForwardRatio" || ud->key == "_fastForwardRatio")
-      {
-        auto value = strtoul(str, NULL, 10);
-        if (value < 2)
-          value = 2;
-        else if (value > 10)
-          value = 10;
-        ud->self->_fastForwardRatio = value;
-      }
+      case JSONSAX_KEY:
+        ud->key = std::string(str, num);
+        break;
+
+      case JSONSAX_BOOLEAN:
+        if (ud->key == "audioWhileFastForwarding" || ud->key == "_audioWhileFastForwarding")
+          ud->self->_audioWhileFastForwarding = num != 0;
+        else if (ud->key == "backgroundInput")
+          ud->self->_backgroundInput = num != 0;
+        else if (ud->key == "showSpeedIndicator")
+          ud->self->_showSpeedIndicator = num != 0;
+        else if (ud->key == "gameFocusCaptureMouse")
+          ud->self->_gameFocusCaptureMouse = num != 0;
+        break;
+
+      case JSONSAX_NUMBER:
+        if (ud->key == "fastForwardRatio" || ud->key == "_fastForwardRatio")
+        {
+          auto value = strtoul(str, NULL, 10);
+          if (value < 2)
+            value = 2;
+          else if (value > 10)
+            value = 10;
+          ud->self->_fastForwardRatio = value;
+        }
+        break;
+
+      case JSONSAX_OBJECT:
+        if (num == 1 && ud->key == "romFolders")
+        {
+          jsonsax_result_t res2 = jsonsax_parse((char*)str, ud, [](void* udata, jsonsax_event_t event, const char* str, size_t num)
+          {
+            auto ud = (Deserialize*)udata;
+
+            if (event == JSONSAX_KEY)
+            {
+              ud->key = std::string(str, num);
+            }
+            else if (event == JSONSAX_STRING)
+            {
+              int system_id = std::stoi(ud->key);
+              ud->self->_romFolders[system_id] = util::jsonUnescape(std::string(str, num));
+            }
+
+            return 0;
+          });
+
+          if (res2 != JSONSAX_OK)
+            return -1;
+        }
+        break;
+
+      default:
+        break;
     }
 
     return 0;

--- a/src/components/Config.h
+++ b/src/components/Config.h
@@ -39,6 +39,8 @@ public:
   virtual const char* getCoreAssetsDirectory() override;
   virtual const char* getSaveDirectory() override;
   virtual const char* getSystemPath() override;
+  virtual const std::string& getRomPath(int system_id) override;
+  virtual void setRomPath(int system_id, const std::string& path) override;
 
   virtual void setVariables(const struct retro_variable* variables, unsigned count) override;
   virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) override;
@@ -144,6 +146,7 @@ protected:
   std::string _saveFolder;
   std::string _systemFolder;
   std::string _screenshotsFolder;
+  std::map<int, std::string> _romFolders;
 
   std::vector<Category> _categories;
   std::vector<Variable> _variables;

--- a/src/libretro/Components.h
+++ b/src/libretro/Components.h
@@ -139,6 +139,8 @@ namespace libretro
     virtual const char* getCoreAssetsDirectory() = 0;
     virtual const char* getSaveDirectory() = 0;
     virtual const char* getSystemPath() = 0;
+    virtual const std::string& getRomPath(int system_id) = 0;
+    virtual void setRomPath(int system_id, const std::string& path) = 0;
 
     virtual void setVariables(const struct retro_variable* variables, unsigned count) = 0;
     virtual void setVariables(const struct retro_core_option_definition* options, unsigned count) = 0;

--- a/src/libretro/Core.cpp
+++ b/src/libretro/Core.cpp
@@ -88,6 +88,16 @@ namespace
       return "./";
     }
 
+    virtual const std::string& getRomPath(int system_id) override
+    {
+      static std::string path = "./";
+      return path;
+    }
+
+    virtual void setRomPath(int system_id, const std::string& path) override
+    {
+    }
+
     virtual void setVariables(const struct retro_variable* variables, unsigned count) override
     {
       (void)variables;


### PR DESCRIPTION
Implements the first part of #298. 

When a game is loaded, the path is associated to the selected system (i.e. NES/N64/Atari2600/etc). And the next time Load Game is selected for that system, the dialog will open at the previous path. The path will also be used as the default location for loading save states.

Similarly, the default folder for importing keybinds will be the location of RAlibretro.

Bookmark and image upload folders need to be managed by the dll.

